### PR TITLE
WIP: SSTOOLKIT-14: login token w/o response parsing ...

### DIFF
--- a/sstoolkit/controllers/base.py
+++ b/sstoolkit/controllers/base.py
@@ -8,6 +8,8 @@ from ..core.version import get_version
 from sstoolkit.configuration.configuration import Configuration
 from sstoolkit.api_client.api_client import ApiClient
 from sstoolkit.api.clients_api import ClientsApi
+from sstoolkit.api.tokens_api import TokensApi
+from sstoolkit.models.token_password import TokenPassword
 from ..rest.rest import ApiException
 
 VERSION_BANNER = """
@@ -22,7 +24,7 @@ class Base(Controller):
 
         description = 'A toolkit for configuring security server'
 
-        epilog = 'Usage: sstoolkit list-clients'
+        epilog = 'Usage: sstoolkit list-clients login-token'
 
         arguments = [
             (['-v', '--version'],
@@ -50,3 +52,27 @@ class Base(Controller):
             pprint(api_response)
         except ApiException as e:
             print("Exception when calling ClientsApi->find_clients: %s\n" % e)
+
+    @ex(
+        help='Login token', arguments=[
+            (['--token-id'], dict(help='TOKEN ID', nargs='?', default=[])),
+            (['--token-pin'], dict(help='TOKEN PIN', nargs='?', default=[]))
+        ]
+    )
+    def login_token(self):
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        with open("config/base.yaml", "r") as ymlfile:
+            cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
+        configuration = Configuration()
+        configuration.api_key['Authorization'] = cfg["base"]["api_key"]
+        configuration.host = cfg["base"]["url"]
+        configuration.verify_ssl = False
+        api_instance = TokensApi(ApiClient(configuration))
+        token_id = self.app.pargs.token_id
+        token_pin = self.app.pargs.token_pin
+
+        try:
+            api_response = api_instance.login_token(id=token_id, body=TokenPassword(password=token_pin))
+            pprint(api_response)
+        except ApiException as e:
+            print("Exception when calling TokensApi->login_token: %s\n" % e)


### PR DESCRIPTION
For comments, not merging at this point.

The operation itself is such that it will only succeed when token is NOT already logged in, so handling such situations where 'no operation is needed' but error is returned warrants some consideration for the whole toolkit

For this particular call, response is with HTTP status code 409 when token is already logged in, body
`` {"status":409,"error":{"code":"action_not_possible"}}`