### PR TITLE
Token listing sstoolkit 22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2020-11-18
+
+- add support for tabulated / json output render
+- token listing to use Cement rendering
+
 ## [0.1.1] - 2020-11-16
 
 - add token listing and login (for default software token) methods

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cement==3.0.4
 pyyaml~=5.3.1
+tabulate~=0.8.7
 
 setuptools>=38.6.0
 urllib3~=1.25.8

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -4,6 +4,8 @@ from xrdsst.configuration.configuration import Configuration
 from xrdsst.controllers.init import BaseController
 import yaml
 
+from xrdsst.main import XRDSSTTest
+
 
 class TestBaseController(unittest.TestCase):
     _ss_config = {
@@ -17,6 +19,12 @@ class TestBaseController(unittest.TestCase):
               'owner_member_code': '1234',
               'security_server_code': 'SS3',
               'software_token_pin': '1234'}]}
+
+    def test_is_output_tabulated(self):
+        with XRDSSTTest() as app:
+            base_controller = BaseController()
+            base_controller.app = app
+            assert base_controller.is_output_tabulated()
 
     def test_load_config(self):
         base_controller = BaseController()

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,11 +1,10 @@
-import os
 import unittest
 from unittest import mock
 from xrdsst.configuration.configuration import Configuration
 from xrdsst.controllers.init import InitServerController
 from xrdsst.models.initialization_status import InitializationStatus
 from xrdsst.rest.rest import ApiException
-import yaml
+
 
 class TestInit(unittest.TestCase):
 

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from dateutil.tz import tzutc
 
+from xrdsst.main import XRDSSTTest
 from xrdsst.models import TokenStatus, TokenType, Key, KeyUsageType, TokenCertificate, CertificateOcspStatus, \
     CertificateStatus, CertificateDetails, KeyUsage
 from xrdsst.models.token import Token
@@ -82,11 +83,13 @@ class TestToken(unittest.TestCase):
               'software_token_pin': '1122'}]}
 
     def test_token_list(self):
-        with mock.patch('xrdsst.api.tokens_api.TokensApi.get_tokens',
-                         return_value=TokenTestData.token_list_response):
-            token_controller = TokenController()
-            token_controller.load_config = (lambda: self.ss_config)
-            token_controller.list()
+        with XRDSSTTest() as app:
+            with mock.patch('xrdsst.api.tokens_api.TokensApi.get_tokens',
+                             return_value=TokenTestData.token_list_response):
+                token_controller = TokenController()
+                token_controller.app = app
+                token_controller.load_config = (lambda: self.ss_config)
+                token_controller.list()
 
     def test_token_login(self):
         with mock.patch('xrdsst.api.tokens_api.TokensApi.login_token',

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -12,6 +12,7 @@ from xrdsst.models.token import Token
 import urllib3
 from xrdsst.controllers.token import TokenController
 
+
 class TokenTestData:
     # JSON of the response unusable due to assertions in generated Client API, define response in Python
     token_login_response = Token(
@@ -67,6 +68,7 @@ class TokenTestData:
     token_list_response = [
         token_login_response
     ]
+
 
 class TestToken(unittest.TestCase):
     ss_config = {

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -34,7 +34,6 @@ class BaseController(Controller):
         try:
             log_file_name = configuration["logging"][0]["file"]
             logging.basicConfig(filename=log_file_name,
-                                filemode='w',
                                 level=configuration["logging"][0]["level"],
                                 format='%(name)s - %(levelname)s - %(message)s')
         except FileNotFoundError as e:

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -19,6 +19,16 @@ class BaseController(Controller):
             (['-v', '--version'], {'action': 'version', 'version': BANNER})
         ]
 
+    # Render arguments differ for back-ends, one approach.
+    def render(self, render_data):
+        if self.is_output_tabulated():
+            self.app.render(render_data, headers="firstrow")
+        else:
+            self.app.render(render_data)
+
+    def is_output_tabulated(self):
+        return self.app.output.Meta.label == 'tabulate'
+
     @staticmethod
     def init_logging(configuration):
         try:

--- a/xrdsst/core/version.py
+++ b/xrdsst/core/version.py
@@ -1,6 +1,6 @@
 from cement.utils.version import get_version as cement_get_version
 
-VERSION = (0, 1, 1, 'alpha', 0)
+VERSION = (0, 1, 2, 'alpha', 0)
 
 
 def get_version(version=VERSION):

--- a/xrdsst/main.py
+++ b/xrdsst/main.py
@@ -1,10 +1,14 @@
-from cement import App, TestApp
+from cement import App, TestApp, init_defaults
 from cement.core.exc import CaughtSignal
 
 from xrdsst.core.exc import XRDSSTError
 from xrdsst.controllers.init import InitServerController
 from xrdsst.controllers.token import TokenController
 from xrdsst.controllers.base import BaseController
+
+META = init_defaults('output.json', 'output.tabulate')
+META['output.json']['overridable'] = True
+META['output.tabulate']['overridable'] = True
 
 class XRDSST(App):
     """X-Road Security Server Toolkit primary application."""
@@ -16,7 +20,12 @@ class XRDSST(App):
         exit_on_close = True
 
         # load additional framework extensions
-        extensions = ['yaml']
+        extensions = ['yaml', 'json', 'tabulate']
+
+        meta_defaults = META
+
+        # set default output format
+        output_handler = 'tabulate'
 
         # register handlers
         handlers = [BaseController, InitServerController, TokenController]


### PR DESCRIPTION
* Allow output in tabulated / json format (see ``-o``), using Cement render calls
* Make token listing use Cement render calls