### PR TITLE
Sstoolkit 13 merge branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.10-alpha.0] - 2020-11-27
+
+- add ``timestamp`` sub-command with ``init`` and some listing proto-bonuses
+
 ## [0.1.9-alpha.0] - 2020-11-24
 
 - add bump2version to handle automatic version updates

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -89,3 +89,7 @@ Default software token login can be logged on with ``xrdsst token login``
 
 All tokens known to security server can be listed with ``xrdsst token list``
 
+### 3.4 Configuring security server to use single approved timestamping service
+
+Single timestamping service approved for use in central server can be configured for security server by invoking ``timestamp`` subcommand
+as ``xrdsst timestamp init``.

--- a/reset_security_server.sh
+++ b/reset_security_server.sh
@@ -15,7 +15,7 @@
 ANSIBLE_CMD="ansible-playbook"
 ANSIBLE_SCRIPT="xroad_init.yml"
 URL=https://localhost:4000/api/v1/api-keys
-ROLES='["XROAD_SYSTEM_ADMINISTRATOR"]'
+ROLES='["XROAD_SYSTEM_ADMINISTRATOR","XROAD_SECURITY_OFFICER"]'
 HEADER='Content-Type: application/json'
 
 usage() {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.9-alpha.0
+current_version = 0.1.10-alpha.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)\.(?P<build>\d+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ test = pytest
 [MASTER]
 ignore = rest,models,resources,api,api_client,configuration
 disable = C0114,C0115,C0116,R0903,W0108,W0511
+max-line-length = 160
 
 [DESIGN]
 max-parents = 10

--- a/tests/unit/test_timestamp.py
+++ b/tests/unit/test_timestamp.py
@@ -37,7 +37,7 @@ class TestTimestamp(unittest.TestCase):
                              return_value=TimestampTestData.timestamp_service_list_response):
                 timestamp_controller = TimestampController()
                 timestamp_controller.app = app
-                timestamp_controller.load_config = (lambda: TestTimestamp.ss_config)
+                timestamp_controller.load_config = (lambda: self.ss_config)
                 timestamp_controller.list_approved()
 
     def test_timestamp_service_configured_list(self):
@@ -46,7 +46,7 @@ class TestTimestamp(unittest.TestCase):
                              return_value=TimestampTestData.timestamp_service_list_response):
                 timestamp_controller = TimestampController()
                 timestamp_controller.app = app
-                timestamp_controller.load_config = (lambda: TestTimestamp.ss_config)
+                timestamp_controller.load_config = (lambda: self.ss_config)
                 timestamp_controller.list_configured()
 
     def test_timestamp_service_init(self):
@@ -57,7 +57,7 @@ class TestTimestamp(unittest.TestCase):
                              return_value=TimestampTestData.timestamp_service_response):
                     timestamp_controller = TimestampController()
                     timestamp_controller.app = app
-                    timestamp_controller.load_config = (lambda: TestTimestamp.ss_config)
+                    timestamp_controller.load_config = (lambda: self.ss_config)
                     timestamp_controller.init()
 
     def test_timestamp_service_init_nonresolving_url(self):
@@ -66,5 +66,5 @@ class TestTimestamp(unittest.TestCase):
                              return_value=TimestampTestData.timestamp_service_list_response):
                 timestamp_controller = TimestampController()
                 timestamp_controller.app = app
-                timestamp_controller.load_config = (lambda: TestTimestamp.ss_config)
+                timestamp_controller.load_config = (lambda: self.ss_config)
                 TestCase.assertRaises(TestTimestamp, urllib3.exceptions.MaxRetryError, lambda: timestamp_controller.init())

--- a/tests/unit/test_timestamp.py
+++ b/tests/unit/test_timestamp.py
@@ -1,6 +1,7 @@
+
 import unittest
-import urllib3
 from unittest import mock, TestCase
+import urllib3
 
 from xrdsst.controllers.timestamp import TimestampController
 from xrdsst.main import XRDSSTTest
@@ -67,5 +68,3 @@ class TestTimestamp(unittest.TestCase):
                 timestamp_controller.app = app
                 timestamp_controller.load_config = (lambda: TestTimestamp.ss_config)
                 TestCase.assertRaises(TestTimestamp, urllib3.exceptions.MaxRetryError, lambda: timestamp_controller.init())
-
-

--- a/tests/unit/test_timestamp.py
+++ b/tests/unit/test_timestamp.py
@@ -1,0 +1,71 @@
+import unittest
+import urllib3
+from unittest import mock, TestCase
+
+from xrdsst.controllers.timestamp import TimestampController
+from xrdsst.main import XRDSSTTest
+from xrdsst.models import TimestampingService
+
+class TimestampTestData:
+    timestamp_service_response = TimestampingService(
+        name='one name to rule them all',
+        url='http://in.the.darkness.bind.them:8899'
+    )
+
+    timestamp_service_list_response = [
+        timestamp_service_response
+    ]
+
+class TestTimestamp(unittest.TestCase):
+    ss_config = {
+        'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
+        'security-server':
+            [{'name': 'ssX',
+              'url': 'https://non.existing.url.blah:8999/api/v1',
+              'api_key': 'X-Road-apikey token=api-key',
+              'configuration_anchor': '/tmp/configuration-anchor.xml',
+              'owner_member_class': 'VOG',
+              'owner_member_code': '4321',
+              'security_server_code': 'SS3',
+              'software_token_id': '0',
+              'software_token_pin': '1122'}]}
+
+    def test_timestamp_service_approved_list(self):
+        with XRDSSTTest() as app:
+            with mock.patch('xrdsst.api.timestamping_services_api.TimestampingServicesApi.get_approved_timestamping_services',
+                             return_value=TimestampTestData.timestamp_service_list_response):
+                timestamp_controller = TimestampController()
+                timestamp_controller.app = app
+                timestamp_controller.load_config = (lambda: TestTimestamp.ss_config)
+                timestamp_controller.list_approved()
+
+    def test_timestamp_service_configured_list(self):
+        with XRDSSTTest() as app:
+            with mock.patch('xrdsst.api.system_api.SystemApi.get_configured_timestamping_services',
+                             return_value=TimestampTestData.timestamp_service_list_response):
+                timestamp_controller = TimestampController()
+                timestamp_controller.app = app
+                timestamp_controller.load_config = (lambda: TestTimestamp.ss_config)
+                timestamp_controller.list_configured()
+
+    def test_timestamp_service_init(self):
+        with XRDSSTTest() as app:
+            with mock.patch('xrdsst.api.timestamping_services_api.TimestampingServicesApi.get_approved_timestamping_services',
+                             return_value=TimestampTestData.timestamp_service_list_response):
+                with mock.patch('xrdsst.api.system_api.SystemApi.add_configured_timestamping_service',
+                             return_value=TimestampTestData.timestamp_service_response):
+                    timestamp_controller = TimestampController()
+                    timestamp_controller.app = app
+                    timestamp_controller.load_config = (lambda: TestTimestamp.ss_config)
+                    timestamp_controller.init()
+
+    def test_timestamp_service_init_nonresolving_url(self):
+        with XRDSSTTest() as app:
+            with mock.patch('xrdsst.api.timestamping_services_api.TimestampingServicesApi.get_approved_timestamping_services',
+                             return_value=TimestampTestData.timestamp_service_list_response):
+                timestamp_controller = TimestampController()
+                timestamp_controller.app = app
+                timestamp_controller.load_config = (lambda: TestTimestamp.ss_config)
+                TestCase.assertRaises(TestTimestamp, urllib3.exceptions.MaxRetryError, lambda: timestamp_controller.init())
+
+

--- a/xrdsst/controllers/timestamp.py
+++ b/xrdsst/controllers/timestamp.py
@@ -1,0 +1,122 @@
+import logging
+import urllib3
+from cement import ex
+
+from .base import BaseController
+from xrdsst.api_client.api_client import ApiClient
+from xrdsst.resources.texts import texts
+from ..api import TimestampingServicesApi
+from xrdsst.api.system_api import SystemApi
+from ..models import TimestampingService
+from ..rest.rest import ApiException
+
+
+class TimestampServiceListMapper:
+    @staticmethod
+    def headers():
+        return ['NAME', 'URL']
+
+    @staticmethod
+    def as_list(timestamping_service):
+        return [timestamping_service.name, timestamping_service.url]
+
+    @staticmethod
+    def as_object(timestamping_service):
+        return {
+            'name' : timestamping_service.name,
+            'url': timestamping_service.url
+        }
+
+
+class TimestampController(BaseController):
+    class Meta:
+        label = 'timestamp'
+        stacked_on = 'base'
+        stacked_type = 'nested'
+        description = texts['timestamp.controller.description']
+
+    # Possible listing approaches for later:
+    #   merged, with approval/configuration flags
+    #   separate, separate subcommands
+    #   merged, with separate command line filtering (--approved, ... etc)
+
+    # Protobonus: approved timestamp services list
+    @ex(label='list-approved', help='List approved timestamping services.', arguments=[])
+    def list_approved(self):
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        self.timestamp_service_list_approved(self.load_config())
+
+    # Protobonus: configured timestamp services list
+    @ex(label='list-configured', help='List configured timestamping services', arguments=[])
+    def list_configured(self):
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        self.timestamp_service_list(self.load_config())
+
+    @ex(help='Select and activate single approved timestamping service.', arguments=[])
+    def init(self):
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        self.timestamp_service_init(self.load_config())
+
+    # Since this is read-only operation, do not log anything, only console output
+    def timestamp_service_list(self, configuration):
+        for security_server in configuration["security-server"]:
+            ss_config = self.initialize_basic_config_values(security_server)
+            self.remote_timestamp_service_list(ss_config, security_server)
+
+    def timestamp_service_list_approved(self, configuration):
+        for security_server in configuration["security-server"]:
+            ss_config = self.initialize_basic_config_values(security_server)
+            self.remote_timestamp_service_list_approved(ss_config, security_server)
+
+    def render_timestamping_services(self, ts_list):
+        render_data = []
+        if self.is_output_tabulated():
+            render_data = [TimestampServiceListMapper.headers()]
+            render_data.extend(map(TimestampServiceListMapper.as_list, ts_list))
+        else:
+            render_data.extend(map(TimestampServiceListMapper.as_object, ts_list))
+        self.render(render_data)
+
+    # Helper for timestamping services listing via TimestampingServices & System APIs.
+    def remote_ts_list(self, apicall):
+        try:
+            ts_list_response = apicall()
+            self.render_timestamping_services(ts_list_response)
+        except ApiException as e:
+            print("Exception when listing timestamping services: %s\n", e)
+
+    def get_approved_timestamping_services(self, ss_configuration):
+        timestamping_api = TimestampingServicesApi(ApiClient(ss_configuration))
+        return timestamping_api.get_approved_timestamping_services()
+
+    def remote_timestamp_service_list_approved(self, ss_configuration, security_server):
+        self.remote_ts_list(lambda: self.get_approved_timestamping_services(ss_configuration))
+
+    def remote_timestamp_service_list(self, ss_configuration, security_server):
+        system_api = SystemApi(ApiClient(ss_configuration))
+        self.remote_ts_list(lambda: system_api.get_configured_timestamping_services())
+
+    def timestamp_service_init(self, configuration): # logging required
+        self.init_logging(configuration)
+        for security_server in configuration["security-server"]:
+            ss_config = self.initialize_basic_config_values(security_server)
+            self.remote_timestamp_service_init(ss_config, security_server)
+
+    def remote_timestamp_service_init(self, ss_configuration, security_server):
+        try:
+            approved_ts = self.get_approved_timestamping_services(ss_configuration)
+            if approved_ts:
+                system_api = SystemApi(ApiClient(ss_configuration))
+                ts_init_response = system_api.add_configured_timestamping_service(
+                    body=TimestampingService(name=approved_ts[0].name, url=approved_ts[0].url)
+                )
+                if ts_init_response: # single timestamping service added is also returned
+                    print(security_server['name'])
+                    self.render_timestamping_services([ts_init_response])
+        except ApiException as excn:
+            if 409 == excn.status:
+                print(security_server['name'], "Timestamping service already configured.")
+            else:
+                tsiferr_msg = "Timestamping service initialization configuration failure"
+                print(security_server['name'], tsiferr_msg, excn)
+                logging.error(security_server['name'] + ' '  + tsiferr_msg, excn)

--- a/xrdsst/core/version.py
+++ b/xrdsst/core/version.py
@@ -1,7 +1,7 @@
 """Module for getting project version"""
 from cement.utils.version import get_version as cement_get_version
 
-CURRENT_VERSION = "0.1.9-alpha.0"
+CURRENT_VERSION = "0.1.10-alpha.0"
 
 
 def convert_version(version_str):

--- a/xrdsst/main.py
+++ b/xrdsst/main.py
@@ -4,6 +4,7 @@ from cement import App, TestApp, init_defaults
 from cement.core.exc import CaughtSignal
 
 from xrdsst.controllers.base import BaseController
+from xrdsst.controllers.timestamp import TimestampController
 from xrdsst.controllers.init import InitServerController
 from xrdsst.controllers.token import TokenController
 
@@ -30,7 +31,7 @@ class XRDSST(App):
         output_handler = 'tabulate'
 
         # register handlers
-        handlers = [BaseController, InitServerController, TokenController]
+        handlers = [BaseController, TimestampController, TokenController, InitServerController]
 
 
 class XRDSSTTest(TestApp, XRDSST):
@@ -38,6 +39,8 @@ class XRDSSTTest(TestApp, XRDSST):
 
     class Meta:
         label = 'xrdsst'
+
+        exit_on_close = False
 
 
 def main():

--- a/xrdsst/resources/texts.py
+++ b/xrdsst/resources/texts.py
@@ -2,4 +2,5 @@ texts = {
     'app.description': 'A toolkit for configuring security server',
     'init.controller.description': 'Initializes security server with configuration anchor.',
     'token.controller.description': 'Commands for performing token operations.',
+    'timestamp.controller.description': 'Commands for performing timestamping service operations.',
 }


### PR DESCRIPTION
* does the selection of single timestamping service, if approved services exist and are not configured ``init``
* contains bonus of listing approved / configured timestamping services, they are both for easing demo and to get discussion going of how we approach this separation (e.g. subcommand name difference like in bonus, subcommand arguments, even something else)