### PR TITLE
Sstoolkit 20 21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ config/base-dev.yaml
 # Ignore PyCharm venv virtual environment
 venv/
 
+# New PyCharm folder
+pyc-env/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.12-alpha.0] - 2020-12-08
+
+- add ``token`` sub-command ``init-keys``
+
 ## [0.1.11-alpha.0] - 2020-12-03
 
 - create Makefile tasks for testing

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -9,6 +9,8 @@ security-server:
     url: https://<SECURITY_SERVER_FQDN_OR_IP>:4000/api/v1
     api_key: X-Road-apikey token=<API_KEY>
     configuration_anchor: /path/to/configuration-anchor.xml
+    owner_dn_country: <OWNER_DISTINGUISHED_NAME_COUNTRY>
+    owner_dn_org: <OWNER_DISTINGUISHED_NAME_ORGANIZATION>
     owner_member_class: <MEMBER_CLASS>
     owner_member_code: <MEMBER_CODE>
     security_server_code: <SERVER_CODE>
@@ -19,6 +21,8 @@ security-server:
     url: https://<SECURITY_SERVER_FQDN_OR_IP>:4000/api/v1
     api_key: X-Road-apikey token=<API_KEY>
     configuration_anchor: /path/to/configuration-anchor.xml
+    owner_dn_country: <OWNER_DISTINGUISHED_NAME_COUNTRY>
+    owner_dn_org: <OWNER_DISTINGUISHED_NAME_ORGANIZATION>
     owner_member_class: <MEMBER_CLASS>
     owner_member_code: <MEMBER_CODE>
     security_server_code: <SERVER_CODE>

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -10,6 +10,7 @@ Doc. ID: XRDSST-CONF
 | 10.11.2020 | 1.0.0       | Initial draft                                                                | Bert Viikmäe       |
 | 12.11.2020 | 1.1.0       | Documentation of initialization functionality                                | Bert Viikmäe       |
 | 16.11.2020 | 1.1.1       | Documentation of token login functionality                                   | Taimo Peelo        |
+| 08.12.2020 | 1.1.2       | Documentation of token key initializations                                   | Taimo Peelo        |
 
 ## Table of Contents
 
@@ -46,6 +47,8 @@ security-server:
     url: https://<SECURITY_SERVER_FQDN_OR_IP>:4000/api/v1
     api_key: X-Road-apikey token=<API_KEY>
     configuration_anchor: /path/to/configuration-anchor.xml
+    owner_dn_country: <OWNER_DISTINGUISHED_NAME_COUNTRY>
+    owner_dn_org: <OWNER_DISTINGUISHED_NAME_ORGANIZATION>
     owner_member_class: <MEMBER_CLASS>
     owner_member_code: <MEMBER_CODE>
     security_server_code: <SERVER_CODE>
@@ -56,6 +59,8 @@ security-server:
 * <SECURITY_SERVER_FQDN_OR_IP> should be substituted with the IP address or host name of the installed security server, e.g. ss1
 * <API_KEY> should be substituted with the api-key of the installed security server
 * /path/to/configuration-anchor.xml should be substituted with the correct path to the configuration anchor file, e.g. "/etc/xroad/configuration-anchor.xml"
+* <OWNER_DISTINGUISHED_NAME_COUNTRY> should be ISO 3166-1 alpha-2 two letter code for server owner country. This is used in certificate generation.
+* <OWNER_DISTINGUISHED_NAME_ORGANIZATION> should be set to server owner organization. This is used in certificate generation.
 * <MEMBER_CLASS> should be substituted with the member class obtained from the Central Server, e.g. GOV
 * <MEMBER_CODE> should be substituted with the member code obtained from the Central Server, e.g. 1234
 * <SERVER_CODE> should be substituted with the server code of the installed security server, e.g. SS1
@@ -94,3 +99,10 @@ All tokens known to security server can be listed with ``xrdsst token list``
 
 Single timestamping service approved for use in central server can be configured for security server by invoking ``timestamp`` subcommand
 as ``xrdsst timestamp init``.
+
+### 3.5 Initializing token keys and corresponding certificate signing requests
+
+Token keys for authentication and signatures can be created with ``xrdsst token init-keys``, which creates
+two keys and generates corresponding certificate signing requests (one for authentication, other for signing).
+The key labels used are conventionally with suffixes ``default-auth-key`` and ``default-sign-key``, if
+those already exist, they will not be duplicated and command acts as no-op for such security server.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.11-alpha.0
+current_version = 0.1.12-alpha.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)\.(?P<build>\d+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.12-alpha.0
+current_version = 0.1.11-alpha.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)\.(?P<build>\d+))?

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -18,6 +18,8 @@ class TestBaseController(unittest.TestCase):
               'url': 'https://ss:4000/api/v1',
               'api_key': 'X-Road-apikey token=api-key',
               'configuration_anchor': configuration_anchor,
+              'owner_dn_country': 'FI',
+              'owner_dn_org': 'UNSERE',
               'owner_member_class': 'GOV',
               'owner_member_code': '1234',
               'security_server_code': 'SS',

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -10,7 +10,8 @@ import urllib3
 from definitions import ROOT_DIR
 from xrdsst.main import XRDSSTTest
 from xrdsst.models import Token, TokenStatus, TokenType, Key, KeyUsageType, TokenCertificate, \
-    CertificateOcspStatus, CertificateStatus, CertificateDetails, KeyUsage
+    CertificateOcspStatus, CertificateStatus, CertificateDetails, KeyUsage, CertificateAuthority, \
+    CertificateAuthorityOcspResponse, SecurityServer, KeyWithCertificateSigningRequestId, TokenCertificateSigningRequest
 
 from xrdsst.controllers.token import TokenController
 
@@ -72,6 +73,50 @@ class TokenTestData:
         token_login_response
     ]
 
+    security_servers_current_server_response = [
+        SecurityServer(
+            id="DEV:GOV:7392:UNS-SSX",
+            instance_id="DEV",
+            member_class="GOV",
+            member_code="7392",
+            server_code="UNS-SSX",
+            server_address="ssX"
+        )
+    ]
+
+    ca_list_response = [
+        CertificateAuthority(
+            name="Some CA",
+            subject_distinguished_name="CN=Some CA, O=Some X-Road CA",
+            issuer_distinguished_name="CN=Some Other CA, O=Some Other X-Road CA",
+            ocsp_response=CertificateAuthorityOcspResponse.OCSP_RESPONSE_UNKNOWN,
+            not_after=datetime(2180, 1, 14, 0, 0, 0),
+            top_ca=True,
+            path="CN=Some Other CA, O=Some Other X-Road CA",
+            authentication_only=False
+        )
+    ]
+
+    add_key_with_csr_response = KeyWithCertificateSigningRequestId(
+        csr_id="16F2B5A9D76B790EE3DD7544152E333FC57F57FF",
+        key=Key(
+            available=True,
+            certificate_signing_requests=[
+                TokenCertificateSigningRequest(
+                    id="16F2B5A9D76B790EE3DD7544152E333FC57F57FF",
+                    owner_id=None,
+                    possible_actions=[]
+                )
+            ],
+            certificates=[],
+            id="D1969303DB4B2CB5A5E0596CF6E4EA9E77D4C405",
+            label="ss1-default-auth-key",
+            name="ss1-default-auth-key",
+            possible_actions=None,
+            saved_to_configuration=True,
+            usage=KeyUsageType.AUTHENTICATION
+        )
+    )
 
 class TestToken(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
@@ -82,6 +127,8 @@ class TestToken(unittest.TestCase):
               'url': 'https://non.existing.url.blah:8999/api/v1',
               'api_key': 'X-Road-apikey token=api-key',
               'configuration_anchor': configuration_anchor,
+              'owner_dn_country': 'FI',
+              'owner_dn_org': 'UNSERE',
               'owner_member_class': 'VOG',
               'owner_member_code': '4321',
               'security_server_code': 'SS3',
@@ -104,6 +151,22 @@ class TestToken(unittest.TestCase):
             token_controller.load_config = (lambda: self.ss_config)
             token_controller.login()
 
+    def test_token_init_keys(self):
+        with XRDSSTTest() as app:
+            with mock.patch('xrdsst.api.certificate_authorities_api.CertificateAuthoritiesApi.get_approved_certificate_authorities') as mock_get_cas:
+                mock_get_cas.return_value.__enter__.return_value = TokenTestData.ca_list_response
+                with mock.patch(
+                        'xrdsst.api.security_servers_api.SecurityServersApi.get_security_servers',
+                        return_value=TokenTestData.security_servers_current_server_response):
+                    with mock.patch('xrdsst.api.tokens_api.TokensApi.get_token',
+                                    return_value=TokenTestData.token_login_response):
+                        with mock.patch('xrdsst.api.tokens_api.TokensApi.add_key_and_csr',
+                                        return_value=TokenTestData.add_key_with_csr_response):
+                            token_controller = TokenController()
+                            token_controller.app = app
+                            token_controller.load_config = (lambda: self.ss_config)
+                            token_controller.init_keys()
+
     def test_token_list_nonresolving_url(self):
         token_controller = TokenController()
         token_controller.load_config = (lambda: self.ss_config)
@@ -113,3 +176,8 @@ class TestToken(unittest.TestCase):
         token_controller = TokenController()
         token_controller.load_config = (lambda: self.ss_config)
         self.assertRaises(urllib3.exceptions.MaxRetryError, lambda: token_controller.login())
+
+    def test_token_init_keys_nonresolving_url(self):
+        token_controller = TokenController()
+        token_controller.load_config = (lambda: self.ss_config)
+        self.assertRaises(urllib3.exceptions.MaxRetryError, lambda: token_controller.init_keys())

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -58,3 +58,13 @@ class BaseController(Controller):
         configuration.host = security_server["url"]
         configuration.verify_ssl = False
         return configuration
+
+    @staticmethod
+    def log_api_error(api_method, exception):
+        logging.error("Exception calling " + api_method + ": " + str(exception))
+        print("Exception calling " + api_method + ": " + str(exception))
+
+    @staticmethod
+    def log_info(message):
+        logging.info(message)
+        print(message)

--- a/xrdsst/controllers/token.py
+++ b/xrdsst/controllers/token.py
@@ -5,7 +5,7 @@ from cement import ex
 from xrdsst.api.security_servers_api import SecurityServersApi
 from xrdsst.api.certificate_authorities_api import CertificateAuthoritiesApi
 from xrdsst.controllers.base import BaseController
-from xrdsst.models import CsrGenerate, KeyUsageType, CsrFormat, KeyLabelWithCsrGenerate, CertificateAuthority
+from xrdsst.models import CsrGenerate, KeyUsageType, CsrFormat, KeyLabelWithCsrGenerate
 from xrdsst.rest.rest import ApiException
 from xrdsst.api_client.api_client import ApiClient
 from xrdsst.api.tokens_api import TokensApi
@@ -172,7 +172,7 @@ class TokenController(BaseController):
             )
 
             if has_sign_key and has_auth_key:
-                print("No key initialization needed.")
+                BaseController.log_info("No key initialization needed.")
                 return
 
             token_api = TokensApi(ApiClient(ss_configuration))

--- a/xrdsst/controllers/token.py
+++ b/xrdsst/controllers/token.py
@@ -2,7 +2,10 @@ import logging
 import urllib3
 from cement import ex
 
+from xrdsst.api.security_servers_api import SecurityServersApi
+from xrdsst.api.certificate_authorities_api import CertificateAuthoritiesApi
 from xrdsst.controllers.base import BaseController
+from xrdsst.models import CsrGenerate, KeyUsageType, CsrFormat, KeyLabelWithCsrGenerate, CertificateAuthority
 from xrdsst.rest.rest import ApiException
 from xrdsst.api_client.api_client import ApiClient
 from xrdsst.api.tokens_api import TokensApi
@@ -46,6 +49,11 @@ class TokenController(BaseController):
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.token_login(self.load_config())
 
+    @ex(help="Initializes two token keys with corresponding AUTH and SIGN CSR generated")
+    def init_keys(self):
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        self.token_add_keys_with_csrs(self.load_config())
+
     def token_list(self, configuration):
         self.init_logging(configuration)
         for security_server in configuration["security-server"]:
@@ -71,10 +79,7 @@ class TokenController(BaseController):
     def token_login(self, configuration):
         self.init_logging(configuration)
         for security_server in configuration["security-server"]:
-            logging.info('Starting configuration process for security server: %s',
-                         security_server['name'])
-            print('Starting configuration process for security server: ' +
-                  security_server['name'])
+            BaseController.log_info('Starting configuration process for security server: ' + security_server['name'])
             ss_configuration = self.initialize_basic_config_values(security_server)
             self.remote_token_login(ss_configuration, security_server)
 
@@ -83,20 +88,138 @@ class TokenController(BaseController):
         token_id = security_server['software_token_id']
         token_pin = security_server['software_token_pin']
         try:
-            logging.info('Performing software token %s login: ', str(token_id))
-            print('Performing software token ' + str(token_id) + ' login: ')
+            BaseController.log_info('Performing software token ' + str(token_id) + ' login: ')
             token_api = TokensApi(ApiClient(ss_configuration))
             token_api.login_token(
                 id=token_id,
                 body=TokenPassword(token_pin)
             )
-            logging.info('Security server \"%s\" token %s logged in', security_server["name"],
-                         str(token_id))
-            print('Security server \"' + security_server["name"] + '\" token ' + str(token_id)
-                  + ' logged in')
+            BaseController.log_info('Security server \"' + security_server["name"] + '\" token ' + str(token_id) + ' logged in')
         except ApiException as err:
             if err.status == 409:
                 print("Token already logged in.")
             else:
-                print("Exception when calling TokensApi->login_token: %s\n" % err)
-                logging.error("Exception when calling TokensApi->login_token: %s\n", err)
+                BaseController.log_api_error('TokensApi->login_token', err)
+
+    def token_add_keys_with_csrs(self, configuration):
+        self.init_logging(configuration)
+        for security_server in configuration["security-server"]:
+            BaseController.log_info('Starting configuration process for security server: '+ security_server['name'])
+            ss_configuration = self.initialize_basic_config_values(security_server)
+            self.remote_token_add_keys_with_csrs(ss_configuration, security_server)
+
+    # requires token to be logged in
+    @staticmethod
+    def remote_token_add_keys_with_csrs(ss_configuration, security_server):
+        def log_creations(results):
+            for result in results:
+                BaseController.log_info(
+                    "Created " + str(result.key.usage) + " CSR '" + result.csr_id +
+                    "' for key '" + result.key.id + "' as '" + result.key.label + "'"
+                )
+
+        responses = []
+
+        token_id = security_server['software_token_id']
+        ss_code = security_server['security_server_code']
+        member_class = security_server['owner_member_class']
+        dn_country = security_server['owner_dn_country']
+        dn_common_name = security_server['owner_member_code']
+        dn_org = security_server['owner_dn_org']
+
+        auth_key_label = security_server['name'] + '-default-auth-key'
+        sign_key_label = security_server['name'] + '-default-sign-key'
+
+        try:
+            ssi = remote_get_security_server_instance(ss_configuration)
+            token = remote_get_token(ss_configuration, security_server)
+            auth_ca = remote_get_auth_certificate_authority(ss_configuration)
+            sign_ca = remote_get_sign_certificate_authority(ss_configuration)
+
+            token_key_labels = list(map(lambda key: key.label, token.keys))
+            has_auth_key = auth_key_label in token_key_labels
+            has_sign_key = sign_key_label in token_key_labels
+
+            # It is not entirely clear how we should approach the formulation of DN, we use sample conventions here,
+            # but it is entirely possible that better conventions or even more configuration should be done. TODO??
+            distinguished_name = {
+                'C': dn_country,
+                'O': dn_org,
+                'CN': dn_common_name,
+                'serialNumber': '/'.join([ssi.member_class, ss_code, member_class])
+            }
+
+            auth_key_req_param = KeyLabelWithCsrGenerate(
+                key_label=auth_key_label,
+                csr_generate_request=CsrGenerate(
+                    key_usage_type=KeyUsageType.AUTHENTICATION,
+                    ca_name=auth_ca.name,
+                    csr_format=CsrFormat.DER,  # Test CA setup at least only works with DER
+                    member_id=':'.join([ssi.instance_id, ssi.member_class, ssi.member_code]),
+                    subject_field_values=distinguished_name
+                )
+            )
+
+            sign_key_req_param = KeyLabelWithCsrGenerate(
+                key_label=sign_key_label,
+                csr_generate_request=CsrGenerate(
+                    key_usage_type=KeyUsageType.SIGNING,
+                    ca_name=sign_ca.name,
+                    csr_format=CsrFormat.DER,  # Test CA setup at least only works with DER
+                    member_id=':'.join([ssi.instance_id, ssi.member_class, ssi.member_code]),
+                    subject_field_values=distinguished_name
+                )
+            )
+
+            if has_sign_key and has_auth_key:
+                print("No key initialization needed.")
+                return
+
+            token_api = TokensApi(ApiClient(ss_configuration))
+            if not has_auth_key:
+                try:
+                    BaseController.log_info('Generating software token ' + str(token_id) + ' key labelled ' + auth_key_label + ' and AUTH CSR: ')
+                    response = token_api.add_key_and_csr(token_id, body=auth_key_req_param)
+                    responses.append(response)
+                except ApiException as err:
+                    BaseController.log_api_error('TokensApi->add_key_and_csr', err)
+                    log_creations(responses)
+
+            if not has_sign_key:
+                try:
+                    BaseController.log_info('Generating software token ' + str(token_id) + " key labelled '" + sign_key_label + "' and SIGN CSR: ")
+                    response = token_api.add_key_and_csr(token_id, body=sign_key_req_param)
+                    responses.append(response)
+                except ApiException as err:
+                    BaseController.log_api_error('TokensApi->add_key_and_csr', err)
+                    log_creations(responses)
+        except Exception as exc:
+            log_creations(responses)
+            raise exc
+
+        log_creations(responses)
+
+
+def remote_get_token(ss_configuration, security_server):
+    token_id = security_server['software_token_id']
+    token_api = TokensApi(ApiClient(ss_configuration))
+    token = token_api.get_token(token_id)
+    return token
+
+
+def remote_get_security_server_instance(ss_configuration):
+    ss_api = SecurityServersApi(ApiClient(ss_configuration))
+    ss_api_response = ss_api.get_security_servers(current_server=True)
+    return ss_api_response.pop()
+
+
+def remote_get_auth_certificate_authority(ss_configuration):
+    ca_api = CertificateAuthoritiesApi(ApiClient(ss_configuration))
+    ca_api_response = ca_api.get_approved_certificate_authorities(key_usage_type=KeyUsageType.AUTHENTICATION)
+    return ca_api_response.pop()
+
+
+def remote_get_sign_certificate_authority(ss_configuration):
+    ca_api = CertificateAuthoritiesApi(ApiClient(ss_configuration))
+    ca_api_response = ca_api.get_approved_certificate_authorities(key_usage_type=KeyUsageType.SIGNING)
+    return ca_api_response.pop()

--- a/xrdsst/core/version.py
+++ b/xrdsst/core/version.py
@@ -1,7 +1,7 @@
 """Module for getting project version"""
 from cement.utils.version import get_version as cement_get_version
 
-CURRENT_VERSION = "0.1.11-alpha.0"
+CURRENT_VERSION = "0.1.12-alpha.0"
 
 
 def convert_version(version_str):

--- a/xrdsst/models/key.py
+++ b/xrdsst/models/key.py
@@ -121,8 +121,9 @@ class Key(object):
         :param name: The name of this Key.  # noqa: E501
         :type: str
         """
-        if name is None:
-            raise ValueError("Invalid value for `name`, must not be `None`")  # noqa: E501
+        #if name is None:
+        #    raise ValueError("Invalid value for `name`, must not be `None`")  # noqa: E501
+        # Not all keys generated on token must have a name # TODO: API change likely?
 
         self._name = name
 
@@ -146,8 +147,9 @@ class Key(object):
         :param label: The label of this Key.  # noqa: E501
         :type: str
         """
-        if label is None:
-            raise ValueError("Invalid value for `label`, must not be `None`")  # noqa: E501
+        #if label is None:
+        #    raise ValueError("Invalid value for `label`, must not be `None`")  # noqa: E501
+        # Not all keys generated on token must have a label # TODO: API change likely?
 
         self._label = label
 
@@ -219,8 +221,9 @@ class Key(object):
         :param usage: The usage of this Key.  # noqa: E501
         :type: KeyUsageType
         """
-        if usage is None:
-            raise ValueError("Invalid value for `usage`, must not be `None`")  # noqa: E501
+        #if usage is None:
+        #    raise ValueError("Invalid value for `usage`, must not be `None`")  # noqa: E501
+        # Keys without CSR cannot have usage type #TODO API change
 
         self._usage = usage
 

--- a/xrdsst/models/token_certificate_signing_request.py
+++ b/xrdsst/models/token_certificate_signing_request.py
@@ -94,8 +94,9 @@ class TokenCertificateSigningRequest(object):
         :param owner_id: The owner_id of this TokenCertificateSigningRequest.  # noqa: E501
         :type: str
         """
-        if owner_id is None:
-            raise ValueError("Invalid value for `owner_id`, must not be `None`")  # noqa: E501
+        # if owner_id is None:
+        #    raise ValueError("Invalid value for `owner_id`, must not be `None`")  # noqa: E501
+        # Simple keys without CSRs are not guaranteed to have owner_id # TODO likely API change
 
         self._owner_id = owner_id
 


### PR DESCRIPTION
* implemented first as separate operations, but that was a headache due to interdependent operations and API defs expecting far too much data from plain keys due to OpenAPI definitions
* after sstoolkit-30 discussions of logic application steps converted to use X-Road API single call that creates key on token and its corresponding CSR (which allows immediate SIGN / AUTH differentiation)
* key created on token configured with 'software_token_id' in ``base.yaml`` under ``security-server`` section
* token operation name -- ``init-keys``
* config file additions (unfortunately information not otherwise available):
```yaml
    owner_dn_country: <OWNER_DISTINGUISHED_NAME_COUNTRY>
    owner_dn_org: <OWNER_DISTINGUISHED_NAME_ORGANIZATION>
```
* certificate fields filled according to some conventions of test data, for some fields, e.g. serial number, there might be improvements possible
* conventional key labels used: prefixed with security server name, suffixed with 'default-PURPOSE-key'
* if conventional keys (by label) are found, they will not be dropped or recreated, performs no-op
