### PR TITLE
Merge of sst30p2:

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cement==3.0.4
 pyyaml~=5.3.1
+networkx~=2.5
 tabulate~=0.8.7
 
 setuptools>=38.6.0

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -128,19 +128,19 @@ class TestBaseController(unittest.TestCase):
         assert response.host == configuration.host
         assert response.verify_ssl == configuration.verify_ssl
 
-    def test_configfile_argument_added(self):
-        base_controller = BaseController()
-        base_controller._parser = Mock()
-        base_parser = base_controller._parser
-        base_parser.add_argument = Mock(return_value=None)
-        base_controller._pre_argument_parsing()
-        base_parser.add_argument.assert_called_once()
+def test_configfile_argument_added():
+    base_controller = BaseController()
+    base_controller._parser = Mock()
+    base_parser = base_controller._parser
+    base_parser.add_argument = Mock(return_value=None)
+    base_controller._pre_argument_parsing()
+    base_parser.add_argument.assert_called_once()
 
-    def test_unsuccessful_app_exit_with_nonexistant_config_spec(self):
-        base_controller = BaseController()
-        base_controller.app = Mock()
-        base_controller.app.pargs = Mock()
-        base_controller.app.pargs.configfile = 'just/not/there/at/all'
-        base_controller.app.close = Mock(return_value=None)
-        base_controller.load_config()
-        base_controller.app.close.assert_called_once_with(os.EX_CONFIG)
+def test_unsuccessful_app_exit_with_nonexistant_config_spec():
+    base_controller = BaseController()
+    base_controller.app = Mock()
+    base_controller.app.pargs = Mock()
+    base_controller.app.pargs.configfile = 'just/not/there/at/all'
+    base_controller.app.close = Mock(return_value=None)
+    base_controller.load_config()
+    base_controller.app.close.assert_called_once_with(os.EX_CONFIG)

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from unittest.mock import Mock
 
 import yaml
 
@@ -49,8 +50,8 @@ class TestBaseController(unittest.TestCase):
 
     def test_load_config_exception(self):
         base_controller = BaseController()
-        config_file = "conf.yaml"
-        self.assertRaises(FileNotFoundError, lambda: base_controller.load_config(config_file))
+        config_file = "/etc/shadow"
+        self.assertRaises(PermissionError, lambda: base_controller.load_config(config_file))
 
     def test_init_logging(self):
         temp_file_name = "temp.log"
@@ -80,3 +81,20 @@ class TestBaseController(unittest.TestCase):
         assert response.api_key == configuration.api_key
         assert response.host == configuration.host
         assert response.verify_ssl == configuration.verify_ssl
+
+    def test_configfile_argument_added(self):
+        base_controller = BaseController()
+        base_controller._parser = Mock()
+        base_parser = base_controller._parser
+        base_parser.add_argument = Mock(return_value=None)
+        base_controller._pre_argument_parsing()
+        base_parser.add_argument.assert_called_once()
+
+    def test_unsuccessful_app_exit_with_nonexistant_config_spec(self):
+        base_controller = BaseController()
+        base_controller.app = Mock()
+        base_controller.app.pargs = Mock()
+        base_controller.app.pargs.configfile = 'just/not/there/at/all'
+        base_controller.app.close = Mock(return_value=None)
+        base_controller.load_config()
+        base_controller.app.close.assert_called_once_with(os.EX_CONFIG)

--- a/tests/unit/test_xrdsst.py
+++ b/tests/unit/test_xrdsst.py
@@ -1,0 +1,13 @@
+from xrdsst.main import opdep_init
+
+
+def test_opdep_init_adds_app_opdep():
+    class JustObject(object):
+        pass
+
+    mock_app = JustObject
+    opdep_init(mock_app)
+    assert mock_app.OP_GRAPH
+    assert mock_app.OP_DEPENDENCY_LIST
+    assert mock_app.OP_GRAPH.number_of_nodes() == len(mock_app.OP_DEPENDENCY_LIST)
+

--- a/tests/unit/test_xrdsst.py
+++ b/tests/unit/test_xrdsst.py
@@ -2,7 +2,7 @@ from xrdsst.main import opdep_init
 
 
 def test_opdep_init_adds_app_opdep():
-    class JustObject(object):
+    class JustObject:
         pass
 
     mock_app = JustObject
@@ -10,4 +10,3 @@ def test_opdep_init_adds_app_opdep():
     assert mock_app.OP_GRAPH
     assert mock_app.OP_DEPENDENCY_LIST
     assert mock_app.OP_GRAPH.number_of_nodes() == len(mock_app.OP_DEPENDENCY_LIST)
-

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -14,10 +14,21 @@ BANNER = texts['app.description'] + ' ' + get_version() + '\n' + get_version_ban
 class BaseController(Controller):
     class Meta:
         label = 'base'
+        stacked_on = 'base'
         description = texts['app.description']
         arguments = [
             (['-v', '--version'], {'action': 'version', 'version': BANNER})
         ]
+
+    def _pre_argument_parsing(self):
+        p = self._parser
+        # Top level configuration file specification only
+        if (issubclass(BaseController, self.__class__)) and issubclass(self.__class__, BaseController):
+            p.add_argument('-c', '--configfile',
+                           # TODO after the conventional name and location for config file gets figured out, extract to texts
+                           help="Specify configuration file to use instead of default 'config/base.yaml'",
+                           metavar='file',
+                           default='config/base.yaml') # TODO extract to consts after settling on naming
 
     # Render arguments differ for back-ends, one approach.
     def render(self, render_data):
@@ -39,17 +50,16 @@ class BaseController(Controller):
         except FileNotFoundError as err:
             print("Configuration file \"" + log_file_name + "\" not found: %s\n" % err)
 
-    @staticmethod
-    def load_config(baseconfig="config/base.yaml"):
-        # Note: this fallback below is to allow simply running xrdsst from both IDE run/debug
-        # and directly from command line. There is no support for configuration
-        # file location spec yet.
-        # TODO: remove fallback when configuration file spec from command-line is implemented
+    def load_config(self, baseconfig=None):
+        if not baseconfig:
+            baseconfig = self.app.pargs.configfile
         if not os.path.exists(baseconfig):
-            baseconfig = os.path.join("..", baseconfig)
-        with open(baseconfig, "r") as yml_file:
-            cfg = yaml.load(yml_file, Loader=yaml.FullLoader)
-        return cfg
+            self.log_info("Cannot load config '" + baseconfig + "'")
+            self.app.close(os.EX_CONFIG)
+        else:
+            with open(baseconfig, "r") as yml_file:
+                cfg = yaml.load(yml_file, Loader=yaml.FullLoader)
+            return cfg
 
     @staticmethod
     def initialize_basic_config_values(security_server):

--- a/xrdsst/main.py
+++ b/xrdsst/main.py
@@ -1,3 +1,4 @@
+import networkx
 import traceback
 
 from cement import App, TestApp, init_defaults
@@ -12,12 +13,63 @@ META = init_defaults('output.json', 'output.tabulate')
 META['output.json']['overridable'] = True
 META['output.tabulate']['overridable'] = True
 
+# Operation dependency graph representation for simple topological ordering
+OP_GRAPH = networkx.DiGraph()
+OP_DEPENDENCY_LIST = []
+
+
+# Operations supported and known at the dependency graph level
+class OPS:
+    INIT = "INIT"
+    TOKEN_LOGIN = "TOKEN\nLOGIN"
+    TIMESTAMP_ENABLE = "TIMESTAMPING"
+    GENKEYS_CSRS ="KEYS AND CSR\nGENERATION"
+    IMPORT_CERTS ="CERTIFICATE\nIMPORT"
+
+
+OP_INIT="INIT"
+OP_TOKEN_LOGIN="TOKEN\nLOGIN"
+OP_TIMESTAMP_ENABLE="TIMESTAMPING"
+OP_GENKEYS_CSRS="KEYS AND CSR\nGENERATION"
+OP_IMPORT_CERTS="CERTIFICATE\nIMPORT"
+
+
+# Initialize operational dependency graph for the security server operations
+def opdep_init(app):
+    graph = OP_GRAPH
+    graph.add_node(OPS.GENKEYS_CSRS,
+                   controller=TokenController, operation=TokenController.init_keys,
+                   configured=False)
+    graph.add_node(OPS.TIMESTAMP_ENABLE,
+                   controller=TimestampController, operation=TimestampController.init,
+                   configured=False)
+    graph.add_node(OPS.INIT,
+                   controller=InitServerController, operation=InitServerController._default,
+                   configured=False)
+    graph.add_node(OPS.TOKEN_LOGIN,
+                   controller=TokenController, operation=TokenController.login,
+                   configured=False)
+
+    graph.add_node(OPS.IMPORT_CERTS)
+    graph.add_edge(OPS.INIT, OPS.TOKEN_LOGIN)
+    graph.add_edge(OPS.INIT, OPS.TIMESTAMP_ENABLE)
+    graph.add_edge(OPS.TOKEN_LOGIN, OPS.GENKEYS_CSRS)
+    graph.add_edge(OPS.GENKEYS_CSRS, OPS.IMPORT_CERTS)
+
+    ts=list(networkx.topological_sort(graph))
+    app.OP_GRAPH = graph
+    app.OP_DEPENDENCY_LIST = ts
+
 
 class XRDSST(App):
     """X-Road Security Server Toolkit primary application."""
 
     class Meta:
         label = 'xrdsst'
+
+        hooks = [
+            ('pre_setup', opdep_init)
+        ]
 
         # call sys.exit() on close
         exit_on_close = True
@@ -51,9 +103,6 @@ def main():
         except AssertionError as err:
             print('AssertionError > %s' % err.args[0])
             app.exit_code = 1
-
-            if app.debug is True:
-                traceback.print_exc()
 
             if app.debug is True:
                 traceback.print_exc()


### PR DESCRIPTION
    SSTOOLKIT-30: dep graph and hook setup

    The minimum operational dependency management.

    * xrdsst acquired '-c' and '--configfile' parameters for specifying the active
      configuration file
    * Operational dependency graph is set up as app.OP_GRAPH
    * Topologically sorted node list of dependency graph for managing operations
      order is set up as app.OP_DEPENDENCY_LIST
    * Operational dependency graph node property 'configured' is set to False, until
      state checks prove otherwise and it is set forcefully
    * Constants with operations are in class OPS of (main.py)
    * Sample of inferred operation order (earlier operations do not depend on later ones)

        print("inferred operation order is", app.OP_DEPENDENCY_LIST)
        for depop in app.OP_DEPENDENCY_LIST:
            that=app.OP_GRAPH.nodes[depop]
            if that.get('operation'):
                print(that['operation'])

    * dot graph definition for visualization of operational dependencies can be generated with
        from networkx.drawing.nx_pydot import write_dot
        networkx.draw(graph)
        write_dot(graph, 'opdep.dot')
      when using pydot (conversion to e.g. PNG with ``dot -Tpng opdep.dot -o opdep.png``