### PR TITLE
Sst36 t2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.19-alpha.0] - 2021-01-12
+
+- add ``xrdsst client`` subcommand ``register``
+
 ## [0.1.18-alpha.0] - 2021-01-07
 
 - add ``xrdsst client`` and subcommand ``add``

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -4,6 +4,7 @@ api_key:
   roles:
   - <SECURITY_SERVER_ROLE_NAME>
   - <SECURITY_SERVER_ROLE_NAME>
+  - <SECURITY_SERVER_ROLE_NAME>
   url: https://localhost:4000/api/v1/api-keys
 logging:
 - file: /path/to/xrdsst.log

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -2,7 +2,7 @@
 
 **Technical Specification**
 
-Version: 1.1.5
+Version: 1.1.6
 Doc. ID: XRDSST-CONF
 
 | Date       | Version     | Description                                                                  | Author             |
@@ -14,6 +14,7 @@ Doc. ID: XRDSST-CONF
 | 15.12.2020 | 1.1.3       | Documentation of api-key parameterization                                    | Bert Viikmäe       |
 | 22.12.2020 | 1.1.4       | Brief notes on certificate management                                        | Taimo Peelo        |
 | 30.12.2020 | 1.1.5       | Note on certificate activation                                               | Taimo Peelo        |
+| 12.01.2021 | 1.1.6       | Notes on client management                                                   | Taimo Peelo        |
 
 
 ## Table of Contents
@@ -160,3 +161,4 @@ cert register``, final activation with ``xrdsst cert activate``.
 ### 3.7 Client management
 Client subsystems are managed with ``xrdsst client`` subcommands, new subsystem client can be added with
 ``xrdsst client add``, the subsystem parameters should be specified in the configuration ``clients`` section.
+Further subsystem registration can proceed with ``xrdsst client register``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.18-alpha.0
+current_version = 0.1.19-alpha.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)\.(?P<build>\d+))?

--- a/tests/integration/test_xrdsst.py
+++ b/tests/integration/test_xrdsst.py
@@ -26,7 +26,7 @@ def waitfor(boolf, delay, retries):
         count += 1
 
     if count >= retries:
-        raise Exception("Exceeded retry count " + retries + " with delay " + delay)
+        raise Exception("Exceeded retry count " + str(retries) + " with delay " + str(delay) + "s.")
 
 
 # Returns TEST CA signed certificate in PEM format.

--- a/tests/integration/test_xrdsst.py
+++ b/tests/integration/test_xrdsst.py
@@ -242,6 +242,13 @@ class TestXRDSST(unittest.TestCase):
             client_controller.load_config = (lambda: self.config)
             client_controller.add()
 
+    def step_subsystem_register(self):
+        with XRDSSTTest() as app:
+            client_controller = ClientController()
+            client_controller.app = app
+            client_controller.load_config = (lambda: self.config)
+            client_controller.register()
+
     def test_run_configuration(self):
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.step_init()
@@ -260,3 +267,4 @@ class TestXRDSST(unittest.TestCase):
         # subsystems
         self.apply_subsystem_config()
         self.step_subsystem_add()
+        self.step_subsystem_register()

--- a/tests/integration/test_xrdsst.py
+++ b/tests/integration/test_xrdsst.py
@@ -17,15 +17,27 @@ from xrdsst.controllers.timestamp import TimestampController
 from xrdsst.controllers.token import TokenController
 from xrdsst.main import XRDSSTTest
 
+
+# Waits until boolean function returns True within number of retried delays or raises error
+def waitfor(boolf, delay, retries):
+    count = 0
+    while count < retries and not boolf():
+        time.sleep(delay)
+        count += 1
+
+    if count >= retries:
+        raise Exception("Exceeded retry count " + retries + " with delay " + delay)
+
+
 # Returns TEST CA signed certificate in PEM format.
-def perform_test_ca_sign(test_ca_sign_url, certfile_loc, type):
+def perform_test_ca_sign(test_ca_sign_url, certfile_loc, _type):
     certfile = open(certfile_loc, "rb")  # opening for [r]eading as [b]inary
     cert_data = certfile.read()
     certfile.close()
 
     response = requests.post(
         test_ca_sign_url,
-        {'type': type},
+        {'type': _type},
         files={
             'certreq': (os.path.basename(certfile_loc), cert_data, 'application/x-x509-ca-cert')
         }
@@ -33,6 +45,7 @@ def perform_test_ca_sign(test_ca_sign_url, certfile_loc, type):
 
     # Test CA returns plain PEMs only
     return response.content.decode("ascii")
+
 
 # Deduce possible TEST CA URL from configuration anchor
 def find_test_ca_sign_url(conf_anchor_file_loc):
@@ -49,6 +62,30 @@ def find_test_ca_sign_url(conf_anchor_file_loc):
         return protocol + "://" + host + ":" + str(port) + prefix + suffix
 
 
+# Check for auth cert registration update receival
+def auth_cert_registration_global_configuration_update_received(config):
+    def registered_auth_key(key):
+        return BaseController.default_auth_key_label(config["security_server"][0]) == key['label'] and \
+               'REGISTERED' == key['certificates'][0]['status']
+
+    result = requests.get(
+        config["security_server"][0]["url"] + "/tokens/" + str(config["security_server"][0]['software_token_id']),
+        None,
+        headers={
+            'Authorization': config["security_server"][0]["api_key"],
+            'accept': 'application/json'
+        },
+        verify=False
+    )
+
+    if result.status_code != 200:
+        raise Exception("Failed registration status check, status " + result.status_code + ": " + result.reason)
+
+    response = json.loads(result.content)
+    registered_auth_keys = list(filter(registered_auth_key, response['keys']))
+    return True if registered_auth_keys else False
+
+
 class TestXRDSST(unittest.TestCase):
 
     configuration_anchor = "tests/resources/configuration-anchor.xml"
@@ -59,10 +96,10 @@ class TestXRDSST(unittest.TestCase):
     docker_folder = local_folder + '/Docker/securityserver'
     image = 'xroad-security-server:latest'
     url = 'https://localhost:4000/api/v1/api-keys'
-    roles = '[\"XROAD_SYSTEM_ADMINISTRATOR\",\"XROAD_SECURITY_OFFICER\"]'
+    roles = '[\"XROAD_SYSTEM_ADMINISTRATOR\",\"XROAD_SECURITY_OFFICER\", \"XROAD_REGISTRATION_OFFICER\"]'
     header = 'Content-Type: application/json'
-    max_retries = 60
-    curl_retry_wait_seconds = 5
+    max_retries = 300
+    retry_wait = 1 # in seconds
     name = None
     config = None
 
@@ -71,10 +108,10 @@ class TestXRDSST(unittest.TestCase):
             'logging': [{'file': '/var/log/xrdsst_test.log', 'level': 'INFO'}],
             'api_key': [{'url': self.url,
                          'key': 'key',
-                         'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
+                         'roles': json.loads(self.roles)}],
             'security_server':
                 [{'name': 'ss',
-                  'url': 'https://localhost:8000/api/v1',
+                  'url': 'https://CONTAINER_HOST:4000/api/v1',
                   'api_key': 'X-Road-apikey token=a2e9dea1-de53-4ebc-a750-6be6461d91f0',
                   'configuration_anchor': os.path.join(ROOT_DIR, self.configuration_anchor),
                   'owner_dn_country': 'EE',
@@ -90,6 +127,11 @@ class TestXRDSST(unittest.TestCase):
     def set_api_key(self, api_key):
         self.config["security_server"][0]["api_key"] = 'X-Road-apikey token=' + api_key
 
+    def set_ip_url(self, ip_address):
+        local_url = self.config["security_server"][0]["url"]
+        container_ip_url = local_url.replace("CONTAINER_HOST", ip_address)
+        self.config["security_server"][0]["url"] = container_ip_url
+
     def setUp(self):
         self.load_config()
         self.clean_docker()
@@ -97,6 +139,18 @@ class TestXRDSST(unittest.TestCase):
         client = docker.from_env()
         self.build_image(client)
         self.run_container(client)
+
+        # Wait for functional networking to be started up, with side effect of configuration update.
+        container_ip = ''
+        count = 0
+        while not container_ip and count < self.max_retries:
+            time.sleep(self.retry_wait)
+            count += 1
+            container_ip = client.containers.list(filters={"name": self.name})[0].attrs['NetworkSettings']['IPAddress']
+        if count >= self.max_retries and not container_ip:
+            raise Exception("Unable to acquire network address of the container '" + self.name + "'.")
+
+        self.set_ip_url(container_ip)
         self.create_api_key(client)
 
     def tearDown(self):
@@ -116,10 +170,11 @@ class TestXRDSST(unittest.TestCase):
         containers = client.containers.list(filters={"name": self.name})
         if len(containers) == 0:
             client.containers.run(detach=True, name=self.name, image=self.image, ports={'4000/tcp': 8000})
+        elif len(containers) == 1:
+            if containers[0].status != 'running':
+                containers[0].restart()
         else:
-            for container in containers:
-                if container.status != 'running':
-                    container.restart()
+            raise Exception("Encountered multiple containers named '" + self.name + "', no action taken.")
 
     def create_api_key(self, client):
         containers = client.containers.list(filters={"name": self.name})
@@ -134,7 +189,7 @@ class TestXRDSST(unittest.TestCase):
                         json_data = json.loads(result.output)
                         self.set_api_key(json_data["key"])
                         break
-                    time.sleep(self.curl_retry_wait_seconds)
+                    time.sleep(self.retry_wait)
                     retries += 1
 
     def clean_docker(self):
@@ -263,6 +318,9 @@ class TestXRDSST(unittest.TestCase):
         self.step_cert_import()
         self.step_cert_register()
         self.step_cert_activate()
+
+        # Wait for global configuration status updates
+        waitfor(lambda: auth_cert_registration_global_configuration_update_received(self.config), self.retry_wait, self.max_retries)
 
         # subsystems
         self.apply_subsystem_config()

--- a/tests/resources/test-config-template.yaml
+++ b/tests/resources/test-config-template.yaml
@@ -4,6 +4,7 @@ api_key:
   roles:
   - XROAD_SYSTEM_ADMINISTRATOR
   - XROAD_SECURITY_OFFICER
+  - XROAD_REGISTRATION_OFFICER
   url: https://localhost:4000/api/v1/api-keys
 logging:
 - file: /var/log/xroad/xrdsst.log

--- a/xrdsst/controllers/client.py
+++ b/xrdsst/controllers/client.py
@@ -5,7 +5,7 @@ from cement import ex
 from xrdsst.api import ClientsApi
 from xrdsst.api_client.api_client import ApiClient
 from xrdsst.controllers.base import BaseController
-from xrdsst.models import ClientAdd, Client, ConnectionType
+from xrdsst.models import ClientAdd, Client, ConnectionType, ClientStatus
 from xrdsst.rest.rest import ApiException
 from xrdsst.resources.texts import texts
 
@@ -22,6 +22,11 @@ class ClientController(BaseController):
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.add_client(self.load_config())
 
+    @ex(help="Register client", arguments=[])
+    def register(self):
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        self.register_client(self.load_config())
+
     def add_client(self, configuration):
         self.init_logging(configuration)
         for security_server in configuration["security_server"]:
@@ -29,6 +34,14 @@ class ClientController(BaseController):
             ss_configuration = self.initialize_basic_config_values(security_server, configuration)
             for client in security_server["clients"]:
                 self.remote_add_client(ss_configuration, client)
+
+    def register_client(self, configuration):
+        self.init_logging(configuration)
+        for security_server in configuration["security_server"]:
+            BaseController.log_info('Starting client registrations for security server: ' + security_server['name'])
+            ss_configuration = self.initialize_basic_config_values(security_server, configuration)
+            for client in security_server["clients"]:
+                self.remote_register_client(ss_configuration, security_server, client)
 
     @staticmethod
     def remote_add_client(ss_configuration, client_conf):
@@ -48,6 +61,43 @@ class ClientController(BaseController):
                 BaseController.log_info("Client for '" + partial_client_id(client_conf) + "' already exists.")
             else:
                 BaseController.log_api_error('ClientsApi->add_client', err)
+
+    @staticmethod
+    def remote_register_client(ss_configuration, security_server_conf, client_conf):
+        client = None
+        clients_api = ClientsApi(ApiClient(ss_configuration))
+        try:
+            found_clients = clients_api.find_clients(
+                member_class=client_conf['member_class'],
+                member_code=client_conf['member_code'],
+                subsystem_code=client_conf['subsystem_code']
+            )
+
+            if not found_clients:
+                BaseController.log_info(
+                    security_server_conf['name'] + ": Client matching " + partial_client_id(client_conf) + " not found")
+                return
+
+            if len(found_clients) > 1:
+                BaseController.log_info(
+                    security_server_conf['name'] + ": Error, multiple matching clients found for " + partial_client_id(client_conf)
+                )
+                return
+
+            client = found_clients[0]
+            if ClientStatus.SAVED != client.status:
+                BaseController.log_info(
+                    security_server_conf['name'] + ": " + partial_client_id(client_conf) + " already registered."
+                )
+                return
+
+            try:
+                clients_api.register_client(id=client.id)
+                BaseController.log_info("Registered client " + partial_client_id(client_conf))
+            except ApiException as reg_err:
+                BaseController.log_api_error('ClientsApi->register_client', reg_err)
+        except ApiException as find_err:
+            BaseController.log_api_error('ClientsApi->find_clients', find_err)
 
 
 def partial_client_id(client_conf):

--- a/xrdsst/controllers/client.py
+++ b/xrdsst/controllers/client.py
@@ -64,7 +64,6 @@ class ClientController(BaseController):
 
     @staticmethod
     def remote_register_client(ss_configuration, security_server_conf, client_conf):
-        client = None
         clients_api = ClientsApi(ApiClient(ss_configuration))
         try:
             found_clients = clients_api.find_clients(

--- a/xrdsst/core/version.py
+++ b/xrdsst/core/version.py
@@ -1,7 +1,7 @@
 """Module for getting project version"""
 from cement.utils.version import get_version as cement_get_version
 
-CURRENT_VERSION = "0.1.18-alpha.0"
+CURRENT_VERSION = "0.1.19-alpha.0"
 
 
 def convert_version(version_str):


### PR DESCRIPTION
Adds subsystem/client registration functionality.

* API key used must have ``XROAD_REGISTRATION_OFFICER`` role for subsystem adding / registration
  
To run the integration tests, central server needs to have:
 * ORG:GOV:1234 member defined.
 * autoconfiguration must be enabled in center.ini (or local.ini?) 
```
   [center]
   auto-approve-auth-cert-reg-requests=true
   auto-approve-client-reg-requests=true
```
 * management services via security server must be configured, with client access for ``security-server-owners``
 * management services security server must be accessible via IP address
 * management services security server must be accessible from Docker container