### PR TITLE
Sstoolkit 49p1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.20-alpha.0] - 2021-01-21
+
+- add ``xrdsst apply`` autoconfiguration command, rework log error handling
+
 ## [0.1.19-alpha.0] - 2021-01-12
 
 - add ``xrdsst client`` subcommand ``register``

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -1,3 +1,6 @@
+logging:
+  file: /path/to/xrdsst.log
+  level: <LOG_LEVEL>
 api_key:
 - credentials: xrd:secret
   key: /path/to/ssh_private_key
@@ -6,9 +9,6 @@ api_key:
   - <SECURITY_SERVER_ROLE_NAME>
   - <SECURITY_SERVER_ROLE_NAME>
   url: https://localhost:4000/api/v1/api-keys
-logging:
-- file: /path/to/xrdsst.log
-  level: <LOG_LEVEL>
 security_server:
 - api_key: X-Road-apikey token=<API_KEY>
   certificates:

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -122,10 +122,10 @@ $ xrdsst
 
 Which currently gives further information about tool invocation options and subcommands.
 
-### 3.1 The automatic configuration of a single security server
+### 3.1 The automatic configuration of security servers listed in configuration file
 
 ```
-$ xrdsst init
+$ xrdsst apply
 ```
 
 In the first stage of the automatic process, the security server(s) will be initialized according to the configuration data specified

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -55,15 +55,15 @@ The automatic configuration of X-Road security servers using the X-Road Security
 
 ### 2.2 Format of configuration file
 ```
+logging:
+  file: /path/to/xrdsst.log
+  level: <LOG_LEVEL>
 api-key:
 - credentials: <SECURITTY_SERVER_CREDENTIALS>
   key: /path/to/ssh_private_key
   roles:
   - <SECURITY_SERVER_ROLE_NAME>
   url: https://localhost:4000/api/v1/api-keys
-logging:
-- file: /path/to/xrdsst.log
-  level: <LOG_LEVEL>
 security-server:
 - api_key: X-Road-apikey token=<API_KEY>
   configuration_anchor: /path/to/configuration-anchor.xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.19-alpha.0
+current_version = 0.1.20-alpha.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)\.(?P<build>\d+))?

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -1,0 +1,1 @@
+temp.log

--- a/tests/unit/test_auto.py
+++ b/tests/unit/test_auto.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest import mock
+
+
+from xrdsst.controllers.base import BaseController
+from xrdsst.controllers.auto import AutoController
+from xrdsst.controllers.cert import CertController
+from xrdsst.controllers.init import InitServerController
+from xrdsst.controllers.timestamp import TimestampController
+from xrdsst.controllers.token import TokenController
+from xrdsst.main import XRDSSTTest
+
+
+class ObjectStruct:
+    def __init__(self, **entries): self.__dict__.update(entries)
+
+    def __eq__(self, other): return self.__dict__ == other.__dict__
+
+    def __ne__(self, other): return self.__dict__ != other.__dict__
+
+
+class TestAuto(unittest.TestCase):
+    ss_config = {
+        'api_key': [{'url': 'https://localhost:4000/api/v1/api-keys',
+                     'key': 'private key',
+                     'credentials': 'user:pass',
+                     'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
+        'security_server':
+            [{'name': 'ssX',
+              'url': 'https://non.existing.url.blah:8999/api/v1',
+              'api_key': 'X-Road-apikey token=api-key',
+              }]}
+
+    @mock.patch.object(XRDSSTTest, 'pargs', ObjectStruct(configfile=BaseController.config_file))
+    @mock.patch.object(BaseController, 'load_config', (lambda x, y=None: TestAuto.ss_config))
+    @mock.patch.object(CertController, 'activate')
+    @mock.patch.object(CertController, 'register')
+    @mock.patch.object(CertController, 'import_')
+    @mock.patch.object(TokenController, 'init_keys')
+    @mock.patch.object(TokenController, 'login')
+    @mock.patch.object(TimestampController, 'init')
+    @mock.patch.object(InitServerController, '_default')
+    def test_autoconfig(self, init_mock, timestamp_init_mock, token_login_mock, token_key_init_mock, cert_import_mock, cert_register_mock, cert_activate_mock):
+        with XRDSSTTest() as app:
+            auto_controller = AutoController()
+            auto_controller.app = app
+            auto_controller._default()
+
+            init_mock.assert_called_once()
+            timestamp_init_mock.assert_called_once()
+            token_login_mock.assert_called_once()
+            token_key_init_mock.assert_called_once()
+            cert_import_mock.assert_called_once()
+            cert_register_mock.assert_called_once()
+            cert_activate_mock.assert_called_once()

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 from xrdsst.configuration.configuration import Configuration
 from xrdsst.controllers.init import InitServerController
+from xrdsst.models import TokenInitStatus
 from xrdsst.models.initialization_status import InitializationStatus
 from xrdsst.rest.rest import ApiException
 from tests.unit.test_base_controller import TestBaseController
@@ -78,7 +79,7 @@ class TestInit(unittest.TestCase):
         initialization_status = InitializationStatus(is_anchor_imported=True,
                                                      is_server_code_initialized=True,
                                                      is_server_owner_initialized=True,
-                                                     software_token_init_status='INITLIALIZED')
+                                                     software_token_init_status=TokenInitStatus.INITIALIZED)
         with mock.patch('xrdsst.controllers.init.InitializationApi.get_initialization_status',
                         return_value=initialization_status):
             init = InitServerController()
@@ -89,7 +90,7 @@ class TestInit(unittest.TestCase):
         initialization_status = InitializationStatus(is_anchor_imported=False,
                                                      is_server_code_initialized=False,
                                                      is_server_owner_initialized=False,
-                                                     software_token_init_status='NOT_INITLIALIZED')
+                                                     software_token_init_status=TokenInitStatus.NOT_INITIALIZED)
         with mock.patch('xrdsst.controllers.init.InitializationApi.get_initialization_status',
                         return_value=initialization_status):
             with mock.patch('xrdsst.controllers.init.SystemApi.upload_initial_anchor',

--- a/xrdsst/controllers/auto.py
+++ b/xrdsst/controllers/auto.py
@@ -1,0 +1,31 @@
+from cement import ex
+from xrdsst.controllers.base import BaseController
+from xrdsst.resources.texts import texts
+
+
+class AutoController(BaseController):
+    class Meta:
+        label = 'apply'
+        stacked_on = 'base'
+        stacked_type = 'nested'
+        description = texts['auto.controller.description']
+
+    @ex(help='autoconfig', hide=True)
+    def _default(self):
+        config_file = self.load_config()
+        self._doit(config_file)
+
+    def _doit(self, config_file):
+        self.init_logging(config_file)
+        self.auto_ss()
+
+    def auto_ss(self):
+        for dep_op in self.app.OP_DEPENDENCY_LIST:
+            op_node = self.app.OP_GRAPH.nodes[dep_op]
+            if op_node.get('operation'):
+                if not op_node['controller'] in self.app.Meta.handlers:
+                    raise Exception("No registered controller " + str(op_node['controller']) + " found.")
+
+                ctr = op_node['controller']()
+                ctr.app = self.app
+                op_node['operation'](ctr)

--- a/xrdsst/controllers/cert.py
+++ b/xrdsst/controllers/cert.py
@@ -1,6 +1,5 @@
 import os
 
-import urllib3
 import cement.utils.fs
 
 from cement import ex
@@ -53,22 +52,18 @@ class CertController(BaseController):
 
     @ex(help="Import certificate(s)", label="import", arguments=[])
     def import_(self):
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.import_certificates(self.load_config())
 
     @ex(help="Register authentication certificate(s)", arguments=[])
     def register(self):
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.register_certificate(self.load_config())
 
     @ex(help="Activate registered centrally approved authentication certificate", arguments=[])
     def activate(self):
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.activate_certificate(self.load_config())
 
     @ex(help="Download certificate requests for sign and auth keys, if any.", arguments=[])
     def download_csrs(self):
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         return self._download_csrs(self.load_config())
 
     def import_certificates(self, configuration):

--- a/xrdsst/controllers/client.py
+++ b/xrdsst/controllers/client.py
@@ -1,5 +1,3 @@
-import urllib3
-
 from cement import ex
 
 from xrdsst.api import ClientsApi
@@ -19,12 +17,10 @@ class ClientController(BaseController):
 
     @ex(help="Add client subsystem", arguments=[])
     def add(self):
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.add_client(self.load_config())
 
     @ex(help="Register client", arguments=[])
     def register(self):
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.register_client(self.load_config())
 
     def add_client(self, configuration):

--- a/xrdsst/controllers/init.py
+++ b/xrdsst/controllers/init.py
@@ -1,5 +1,3 @@
-import urllib3
-
 from cement import ex
 from xrdsst.controllers.base import BaseController
 from xrdsst.models import InitialServerConf
@@ -19,7 +17,6 @@ class InitServerController(BaseController):
 
     @ex(help='Initialize security server', hide=True)
     def _default(self):
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         config_file = self.load_config()
         self.initialize_server(config_file)
 

--- a/xrdsst/controllers/timestamp.py
+++ b/xrdsst/controllers/timestamp.py
@@ -1,5 +1,4 @@
 import logging
-import urllib3
 from cement import ex
 
 from .base import BaseController
@@ -43,18 +42,15 @@ class TimestampController(BaseController):
     # Protobonus: approved timestamp services list
     @ex(label='list-approved', help='List approved timestamping services.', arguments=[])
     def list_approved(self):
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.timestamp_service_list_approved(self.load_config())
 
     # Protobonus: configured timestamp services list
     @ex(label='list-configured', help='List configured timestamping services', arguments=[])
     def list_configured(self):
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.timestamp_service_list(self.load_config())
 
     @ex(help='Select and activate single approved timestamping service.', arguments=[])
     def init(self):
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.timestamp_service_init(self.load_config())
 
     # Since this is read-only operation, do not log anything, only console output

--- a/xrdsst/controllers/token.py
+++ b/xrdsst/controllers/token.py
@@ -1,4 +1,3 @@
-import urllib3
 from cement import ex
 
 from xrdsst.api.security_servers_api import SecurityServersApi
@@ -41,17 +40,14 @@ class TokenController(BaseController):
 
     @ex(help='List tokens', arguments=[])
     def list(self):
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.token_list(self.load_config())
 
     @ex(help='Login token', arguments=[])
     def login(self):
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.token_login(self.load_config())
 
     @ex(help="Initializes two token keys with corresponding AUTH and SIGN CSR generated")
     def init_keys(self):
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.token_add_keys_with_csrs(self.load_config())
 
     def token_list(self, config):

--- a/xrdsst/core/version.py
+++ b/xrdsst/core/version.py
@@ -1,7 +1,7 @@
 """Module for getting project version"""
 from cement.utils.version import get_version as cement_get_version
 
-CURRENT_VERSION = "0.1.19-alpha.0"
+CURRENT_VERSION = "0.1.20-alpha.0"
 
 
 def convert_version(version_str):

--- a/xrdsst/main.py
+++ b/xrdsst/main.py
@@ -4,16 +4,19 @@ import os
 import subprocess
 import traceback
 
+import urllib3
 import yaml
 from cement import App, TestApp, init_defaults
 from cement.core.exc import CaughtSignal
 
+from xrdsst.controllers.auto import AutoController
 from xrdsst.controllers.base import BaseController
 from xrdsst.controllers.cert import CertController
 from xrdsst.controllers.client import ClientController
 from xrdsst.controllers.timestamp import TimestampController
 from xrdsst.controllers.init import InitServerController
 from xrdsst.controllers.token import TokenController
+from xrdsst.resources.texts import texts
 
 META = init_defaults('output.json', 'output.tabulate')
 META['output.json']['overridable'] = True
@@ -23,26 +26,39 @@ META['output.tabulate']['overridable'] = True
 OP_GRAPH = networkx.DiGraph()
 OP_DEPENDENCY_LIST = []
 
-
-# Operations supported and known at the dependency graph level
-class OPS:
-    INIT = "INIT"
-    TOKEN_LOGIN = "TOKEN\nLOGIN"
-    TIMESTAMP_ENABLE = "TIMESTAMPING"
-    GENKEYS_CSRS ="KEYS AND CSR\nGENERATION"
-    IMPORT_CERTS ="CERTIFICATE\nIMPORT"
-
-
 OP_INIT="INIT"
 OP_TOKEN_LOGIN="TOKEN\nLOGIN"
 OP_TIMESTAMP_ENABLE="TIMESTAMPING"
 OP_GENKEYS_CSRS="KEYS AND CSR\nGENERATION"
 OP_IMPORT_CERTS="CERTIFICATE\nIMPORT"
+OP_REGISTER_AUTH_CERT="REGISTER\nAUTH CERT"
+OP_ACTIVATE_AUTH_CERT="ACTIVATE\nAUTH CERT"
+
+
+# Operations supported and known at the dependency graph level
+class OPS:
+    INIT = OP_INIT
+    TOKEN_LOGIN = OP_TOKEN_LOGIN
+    TIMESTAMP_ENABLE = OP_TIMESTAMP_ENABLE
+    GENKEYS_CSRS = OP_GENKEYS_CSRS
+    IMPORT_CERTS = OP_IMPORT_CERTS
+    REGISTER_AUTH_CERT = OP_REGISTER_AUTH_CERT
+    ACTIVATE_AUTH_CERT = OP_ACTIVATE_AUTH_CERT
 
 
 # Initialize operational dependency graph for the security server operations
 def opdep_init(app):
     graph = OP_GRAPH
+
+    graph.add_node(OPS.ACTIVATE_AUTH_CERT,
+                   controller=CertController, operation=CertController.activate,
+                   configured=False)
+    graph.add_node(OPS.REGISTER_AUTH_CERT,
+                   controller=CertController, operation=CertController.register,
+                   configured=False)
+    graph.add_node(OPS.IMPORT_CERTS,
+                   controller=CertController, operation=CertController.import_,
+                   configured=False)
     graph.add_node(OPS.GENKEYS_CSRS,
                    controller=TokenController, operation=TokenController.init_keys,
                    configured=False)
@@ -56,13 +72,14 @@ def opdep_init(app):
                    controller=TokenController, operation=TokenController.login,
                    configured=False)
 
-    graph.add_node(OPS.IMPORT_CERTS)
+    graph.add_edge(OPS.REGISTER_AUTH_CERT, OPS.ACTIVATE_AUTH_CERT)
+    graph.add_edge(OPS.IMPORT_CERTS, OPS.REGISTER_AUTH_CERT)
     graph.add_edge(OPS.INIT, OPS.TOKEN_LOGIN)
     graph.add_edge(OPS.INIT, OPS.TIMESTAMP_ENABLE)
     graph.add_edge(OPS.TOKEN_LOGIN, OPS.GENKEYS_CSRS)
     graph.add_edge(OPS.GENKEYS_CSRS, OPS.IMPORT_CERTS)
 
-    ts=list(networkx.topological_sort(graph))
+    ts = list(networkx.topological_sort(graph))
     app.OP_GRAPH = graph
     app.OP_DEPENDENCY_LIST = ts
 
@@ -97,10 +114,11 @@ class XRDSST(App):
     """X-Road Security Server Toolkit primary application."""
 
     class Meta:
-        label = 'xrdsst'
+        label = texts['app.label']
 
         hooks = [
-            ('pre_setup', opdep_init)
+            ('pre_setup', opdep_init),
+            ('pre_setup', lambda app: urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning))
         ]
 
         # call sys.exit() on close
@@ -115,16 +133,18 @@ class XRDSST(App):
         output_handler = 'tabulate'
 
         # register handlers
-        handlers = [BaseController, ClientController, CertController, TimestampController, TokenController, InitServerController]
+        handlers = [BaseController, ClientController, CertController, TimestampController, TokenController, InitServerController, AutoController]
 
 
 class XRDSSTTest(TestApp, XRDSST):
     """A sub-class of XRDSST that is better suited for testing."""
 
     class Meta:
-        label = 'xrdsst'
+        label = texts['app.label'] + "-test"
 
         exit_on_close = False
+
+        handlers = XRDSST.Meta.handlers
 
 
 def main():

--- a/xrdsst/resources/texts.py
+++ b/xrdsst/resources/texts.py
@@ -1,5 +1,7 @@
 texts = {
     'app.description': 'A toolkit for configuring security server',
+    'app.label': 'xrdsst',
+    'auto.controller.description': 'Automatically performs all operations possible with configuration.',
     'cert.controller.description': 'Commands for performing certificate operations.',
     'client.controller.description': 'Commands for performing client management operations.',
     'init.controller.description': 'Initializes security server with configuration anchor.',


### PR DESCRIPTION
* Extensive logging error handling, the logging is now always performed, general logic like discussed on 9th of December 2020:

> Currently the behaviour is that error message is printed out ("Configuration file "/not/existing/folder/file.log" not found: [Errno 2] No such file or directory: '/not/existing/folder/file.log'"), but otherwise the toolkit continues with its work without complaints. Console output should give information, but that is not persistent and console buffers sometimes can only keep rather low number of lines. --- ... several approaches ...
> ...
>  log into user-readable-only newly created file in USER HOME folder, keep the file after run, announce its name at the END of process (e.g. "Activities logged into /home/user/xrdsst-9DRiTimR.log"), so that it would not get lost in short console buffer.

* Multiple log file array is removed from configuration

* Rudimentary but functional autoconfiguration controller, the mythical ``xrdsst apply``, step report / validation part is not merged into this PR, so it currently it is only expected to function well when ideal configuration is created.

Sample autoconfig run when all operation have already been performed and logging is not configured (or configured erroneously) can be expected to be something like this after ``xrdsst apply``:

```
$ xrdsst -c config/ss5-nolog.yaml apply
Starting configuration process for security server: ss5
API key for security server: ss5 has already been created
Configuration anchor for "ss5" already imported
Security server "ss5" already initialized
API key for security server: ss5 has already been created
ss5 Timestamping service already configured.
Starting token login process for security server: ss5
API key for security server: ss5 has already been created
Performing software token 0 login: 
Token already logged in.
Starting token key creation process for security server: ss5
API key for security server: ss5 has already been created
No key initialization needed.
Starting certificate import process for security server: ss5
API key for security server: ss5 has already been created
Certificate '/home/user/folder/ss5-sign-CSR-27FD7449408BBE982679572AE3308BC92DBC81A2-usdcfkc3.pem' already imported.
Certificate '/home/user/folder/ss5-auth-CSR-C7F789B4DEBE74D473027580B1498CF58AC5C714-6s7hv9zp.pem' already imported.
Starting certificate registration process for security server: ss5
API key for security server: ss5 has already been created
No certificates to 'REGISTER' for key labelled 'ss5-default-auth-key'.
Starting certificate activation for security server: ss5
API key for security server: ss5 has already been created
No certificates to 'ACTIVATE' for key labelled 'ss5-default-auth-key'.

Activities logged into '/home/user/xrdsst-20210121-1354-01-rzjz.log'.
```