### PR TITLE
Sstoolkit 49p2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.2-alpha.0] - 2021-02-03
+- Add examination of configured server statuses with ``xrdsst status``
+
 ## [0.2.1-alpha.0] - 2021-01-27
 
 - move adding and enabling of service descriptions to ServiceController

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -2,7 +2,7 @@
 
 **Technical Specification**
 
-Version: 1.1.8
+Version: 1.1.9
 Doc. ID: XRDSST-CONF
 
 | Date       | Version     | Description                                                                  | Author             |
@@ -17,6 +17,7 @@ Doc. ID: XRDSST-CONF
 | 12.01.2021 | 1.1.6       | Notes on client management                                                   | Taimo Peelo        |
 | 20.01.2021 | 1.1.7       | Notes on adding service descriptions                                         | Bert Viikmäe       |
 | 27.01.2021 | 1.1.8       | Notes on enabling service descriptions                                       | Bert Viikmäe       |
+| 03.02.2021 | 1.1.9       | Notes on server status query                                                 | Taimo Peelo        |
 
 ## Table of Contents
 

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -130,6 +130,32 @@ $ xrdsst
 ```
 
 Which currently gives further information about tool invocation options and subcommands.
+Base information about statuses of all defined security servers can be seen with read-only
+``status`` operation:
+
+```
+$ xrdsst status
+╒══════════════════╤══════════════════════╤═════════════════════════╤═══════════════════════╤══════════╤═════════════╤══════════╤═══════════╤═════════╕
+│ GLOBAL           │ SERVER               │ ROLES                   │ INIT                  │ TSAS     │ TOKEN       │ KEYS     │ CSRS      │ CERTS   │
+╞══════════════════╪══════════════════════╪═════════════════════════╪═══════════════════════╪══════════╪═════════════╪══════════╪═══════════╪═════════╡
+│ OK (SUCCESS)     │ ss5                  │ System Administrator    │ ANCHOR INITIALIZED    │ Test TSA │ ID 0        │ SIGN (2) │ AUTH* (1) │ SIGN    │
+│ LAST 131158 0202 │ VER 6.25.0           │ Service Administrator   │ CODE INITIALIZED      │          │ softToken-0 │ AUTH (2) │ 1 CSRS    │ AUTH    │
+│ NEXT 131258 0202 │ DEV:GOV:9876:UNS-SS5 │ Registration Officer    │ OWNER INITIALIZED     │          │ STATUS OK   │ 4 KEYS   │           │         │
+│                  │                      │ Security Officer        │ TOKEN INITIALIZED     │          │ LOGIN NO    │          │           │         │
+│                  │                      │ Securityserver Observer │                       │          │             │          │           │         │
+├──────────────────┼──────────────────────┼─────────────────────────┼───────────────────────┼──────────┼─────────────┼──────────┼───────────┼─────────┤
+│ OK (SUCCESS)     │ ss3                  │ System Administrator    │ ANCHOR INITIALIZED    │ Test TSA │ ID 0        │ SIGN (1) │ SIGN (1)  │         │
+│ LAST 131222 0202 │ VER 6.25.0           │ Service Administrator   │ CODE INITIALIZED      │          │ softToken-0 │ AUTH (1) │ AUTH (1)  │         │
+│ NEXT 131322 0202 │ DEV:GOV:9876:UNS-SS3 │ Registration Officer    │ OWNER INITIALIZED     │          │ STATUS OK   │ 2 KEYS   │ 2 CSRS    │         │
+│                  │                      │ Security Officer        │ TOKEN INITIALIZED     │          │ LOGIN NO    │          │           │         │
+├──────────────────┼──────────────────────┼─────────────────────────┼───────────────────────┼──────────┼─────────────┼──────────┼───────────┼─────────┤
+│ FAIL (INTERNAL)  │ ss4                  │ System Administrator    │ TOKEN NOT_INITIALIZED │          │             │ 0 KEYS   │ 0 CSRS    │         │
+│ LAST 131217 0202 │ VER 6.25.0           │ Security Officer        │                       │          │             │          │           │         │
+│ NEXT 131317 0202 │                      │                         │                       │          │             │          │           │         │
+├──────────────────┼──────────────────────┼─────────────────────────┼───────────────────────┼──────────┼─────────────┼──────────┼───────────┼─────────┤
+│                  │ ss9                  │ NO ACCESS               │                       │          │             │          │           │         │
+╘══════════════════╧══════════════════════╧═════════════════════════╧═══════════════════════╧══════════╧═════════════╧══════════╧═══════════╧═════════╛
+```
 
 ### 3.1 The automatic configuration of security servers listed in configuration file
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1-alpha.0
+current_version = 0.2.2-alpha.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)\.(?P<build>\d+))?

--- a/tests/integration/test_xrdsst.py
+++ b/tests/integration/test_xrdsst.py
@@ -3,23 +3,45 @@ import os
 import subprocess
 import time
 import unittest
+from unittest import mock
 
 import docker
 import git
 import urllib3
 
 from definitions import ROOT_DIR
-from tests.util.test_util import get_service_description, find_test_ca_sign_url, perform_test_ca_sign
+from tests.util.test_util import get_service_description, find_test_ca_sign_url, perform_test_ca_sign, \
+    assert_server_statuses_transitioned
 from tests.util.test_util import get_client, auth_cert_registration_global_configuration_update_received, waitfor
+from xrdsst.controllers.auto import AutoController
 from xrdsst.controllers.base import BaseController
 from xrdsst.controllers.cert import CertController
 from xrdsst.controllers.client import ClientController
 from xrdsst.controllers.init import InitServerController
 from xrdsst.controllers.service import ServiceController
-from xrdsst.controllers.status import StatusController
+from xrdsst.controllers.status import StatusController, ServerStatus
 from xrdsst.controllers.timestamp import TimestampController
 from xrdsst.controllers.token import TokenController
 from xrdsst.main import XRDSSTTest
+
+
+def server_statuses_equal(sl1: [ServerStatus], sl2: [ServerStatus]):
+    assert len(sl1) == len(sl2)
+
+    # Ignore the global status that can have temporal changes and sometimes relies on flaky development central server
+    # Ignore the roles which can freely change and be divided among API keys.
+    for i in range(0, len(sl1)):
+        assert sl1[i].security_server_name == sl2[i].security_server_name # Config match sanity check
+
+        assert sl1[i].version_status.__dict__ == sl2[i].version_status.__dict__
+        assert sl1[i].token_status.__dict__ == sl2[i].token_status.__dict__
+        assert sl1[i].server_init_status.__dict__ == sl2[i].server_init_status.__dict__
+        assert sl1[i].status_keys.__dict__ == sl2[i].status_keys.__dict__
+        assert sl1[i].status_csrs.__dict__ == sl2[i].status_csrs.__dict__
+        assert sl1[i].status_certs.__dict__ == sl2[i].status_certs.__dict__
+        assert sl1[i].timestamping_status == sl2[i].timestamping_status
+
+    return True
 
 
 class TestXRDSST(unittest.TestCase):
@@ -38,7 +60,7 @@ class TestXRDSST(unittest.TestCase):
     name = None
     config = None
 
-    def load_config(self):
+    def init_config(self):
         self.config = {
             'logging': [{'file': '/var/log/xrdsst_test.log', 'level': 'INFO'}],
             'api_key': [{'url': self.url,
@@ -73,6 +95,9 @@ class TestXRDSST(unittest.TestCase):
         self.name = self.config["security_server"][0]["name"]
         return self.config
 
+    def load_config(self):
+        return self.config
+
     def set_api_key(self, api_key):
         self.config["security_server"][0]["api_key"] = 'X-Road-apikey token=' + api_key
 
@@ -82,7 +107,7 @@ class TestXRDSST(unittest.TestCase):
         self.config["security_server"][0]["url"] = container_ip_url
 
     def setUp(self):
-        self.load_config()
+        self.init_config()
         self.clean_docker()
         self.clone_repo()
         client = docker.from_env()
@@ -157,13 +182,15 @@ class TestXRDSST(unittest.TestCase):
             status_controller.app = app
             status_controller.load_config = (lambda: self.config)
 
-            status_controller._default()
+            servers = status_controller._default()
 
             # Must not throw exception, must produce output, test with global status only -- should be ALWAYS present
             # in the configuration that integration test will be run, even when it is still failing as security server
             # has only recently been started up.
             assert status_controller.app._last_rendered[0][1][0].count('LAST') == 1
             assert status_controller.app._last_rendered[0][1][0].count('NEXT') == 1
+
+            return servers
 
     def step_init(self):
         base = BaseController()
@@ -276,10 +303,17 @@ class TestXRDSST(unittest.TestCase):
             service_description = get_service_description(self.config, client_id)
             assert service_description["disabled"] is False
 
+    def step_autoconf(self):
+        with XRDSSTTest() as app:
+            with mock.patch.object(BaseController, 'load_config',  (lambda x, y=None: self.config)):
+                auto_controller = AutoController()
+                auto_controller.app = app
+                auto_controller._default()
+
     def test_run_configuration(self):
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         # Uninitialized security server can already have functioning API interface and status query must function
-        self.query_status()
+        unconfigured_servers_at_start = self.query_status()
         self.step_init()
 
         self.query_status()
@@ -331,4 +365,15 @@ class TestXRDSST(unittest.TestCase):
         self.query_status()
 
         self.step_enable_service_description(client_id)
-        self.query_status()
+        configured_servers_at_end = self.query_status()
+
+        assert_server_statuses_transitioned(unconfigured_servers_at_start, configured_servers_at_end)
+
+        # Run autoconfiguration which should at this stage NOT AFFECT anything since configuration has not been
+        # changed, all operations need to act idempotently and no new errors should occur if previous was successful.
+        self.step_autoconf()
+
+        auto_reconfigured_servers_after = self.query_status()
+        assert server_statuses_equal(configured_servers_at_end, auto_reconfigured_servers_after)
+
+

--- a/tests/unit/test_auto.py
+++ b/tests/unit/test_auto.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest import mock
 
-
+from tests.util.test_util import ObjectStruct
 from xrdsst.controllers.base import BaseController
 from xrdsst.controllers.auto import AutoController
 from xrdsst.controllers.cert import CertController
@@ -9,15 +9,6 @@ from xrdsst.controllers.init import InitServerController
 from xrdsst.controllers.timestamp import TimestampController
 from xrdsst.controllers.token import TokenController
 from xrdsst.main import XRDSSTTest
-
-
-class ObjectStruct:
-    def __init__(self, **entries): self.__dict__.update(entries)
-
-    def __eq__(self, other): return self.__dict__ == other.__dict__
-
-    def __ne__(self, other): return self.__dict__ != other.__dict__
-
 
 class TestAuto(unittest.TestCase):
     ss_config = {

--- a/tests/unit/test_cert.py
+++ b/tests/unit/test_cert.py
@@ -322,9 +322,9 @@ class TestCert(unittest.TestCase):
                     assert cert_controller.app._last_rendered[1].count('ssX-sign') == 1
                     # Check file creation
                     auth_csr_file = list(filter(lambda s: s.count('ssX-auth') > 0,
-                                                map(lambda s: s.strip(), cert_controller.app._last_rendered[1].split('|')))).pop()
+                                                map(lambda s: s.strip(), cert_controller.app._last_rendered[1].split('│')))).pop()
                     sign_csr_file = list(filter(lambda s: s.count('ssX-sign') > 0,
-                                                map(lambda s: s.strip(), cert_controller.app._last_rendered[1].split('|')))).pop()
+                                                map(lambda s: s.strip(), cert_controller.app._last_rendered[1].split('│')))).pop()
                     assert auth_csr_file == reported_downloads[0].fs_loc or auth_csr_file == reported_downloads[1].fs_loc
                     assert sign_csr_file == reported_downloads[0].fs_loc or auth_csr_file == reported_downloads[1].fs_loc
                     assert auth_csr_file != sign_csr_file

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,0 +1,184 @@
+import copy
+import os
+import sys
+import unittest
+from unittest import mock
+
+import pytest
+
+from datetime import datetime, timedelta
+from definitions import ROOT_DIR
+from tests.util.test_util import ObjectStruct
+from xrdsst.api import UserApi, SystemApi, DiagnosticsApi, InitializationApi, SecurityServersApi, TokensApi
+from xrdsst.controllers.status import StatusController
+from xrdsst.main import XRDSSTTest
+from xrdsst.models import Version, User, GlobalConfDiagnostics, InitializationStatus, TokenStatus, SecurityServer, \
+    TimestampingService, Token, PossibleAction, TokenType
+from xrdsst.rest.rest import ApiException
+
+
+class TestStatus(unittest.TestCase):
+    authcert_existing = os.path.join(ROOT_DIR, "tests/resources/authcert.pem")
+    ss_config = {
+        'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
+        'api_key': [{'url': 'https://localhost:4000/api/v1/api-keys',
+                     'key': 'private key',
+                     'credentials': 'user:pass',
+                     'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
+        'security_server':
+            [{'name': 'longServerName',
+              'url': 'https://non.existing.url.blah:8999/api/v1',
+              'certificates': [
+                  '/some/where/authcert',
+                  '/some/where/signcert',
+              ],
+              'api_key': 'X-Road-apikey token=api-key',
+              'owner_dn_country': 'FI',
+              'owner_dn_org': 'UNSERE',
+              'owner_member_class': 'VOG',
+              'owner_member_code': '4321',
+              'security_server_code': 'SS3',
+              'software_token_id': '0',
+              'software_token_pin': '1122'}]}
+
+    def serverless_config(self):
+        config = copy.deepcopy(self.ss_config)
+        config.pop('security_server')
+        return config
+
+    @pytest.fixture(autouse=True)
+    def capsys(self, capsys):
+        self.capsys = capsys
+
+    def test_status_no_security_servers(self):
+        with XRDSSTTest() as app:
+            status_controller = StatusController()
+            status_controller.app = app
+            status_controller.load_config = (lambda: self.serverless_config())
+            status_controller._default()
+
+            out, err = self.capsys.readouterr()
+            assert out.count("No security servers defined") > 0
+            for header in ['GLOBAL', 'SERVER', 'ROLES', 'INIT', 'TSAS', 'TOKEN', 'KEYS', 'CSRS', 'CERTS']:
+                assert header in status_controller.app._last_rendered[0][0]
+
+            with self.capsys.disabled():
+                sys.stdout.write(out)
+                sys.stderr.write(err)
+
+    @mock.patch.object(UserApi, 'get_user', side_effect=ApiException(http_resp=ObjectStruct(status=401, reason=None, data='{"status":401}', getheaders=(lambda: None))))
+    def test_status_api_key_not_accepted(self, userapi_mock):
+        with XRDSSTTest() as app:
+            status_controller = StatusController()
+            status_controller.app = app
+            status_controller.load_config = (lambda: self.ss_config)
+            status_controller._default()
+
+            out, err = self.capsys.readouterr()
+            assert status_controller.app._last_rendered[0][1].count('longServerName') == 1  # Still must report server name in config
+            assert status_controller.app._last_rendered[0][1].count('NO ACCESS') > 0  # ... and inform of access error
+
+            with self.capsys.disabled():
+                sys.stdout.write(out)
+                sys.stderr.write(err)
+
+    @mock.patch.object(UserApi, 'get_user', (lambda x: User(username='api-key-N', permissions=[], roles=['ROLE_XROAD_SYSTEM_ADMINISTRATOR', 'ROLE_XROAD_SECURITY_OFFICER'])))
+    @mock.patch.object(SystemApi, 'system_version', (lambda x: Version(info="6.25.0")))
+    @mock.patch.object(DiagnosticsApi, 'get_global_conf_diagnostics', (lambda x: GlobalConfDiagnostics(status_class="FAIL", status_code="INTERNAL", prev_update_at=datetime.now(), next_update_at=datetime.now() + timedelta(minutes=5))))
+    @mock.patch.object(InitializationApi, 'get_initialization_status', (lambda x: InitializationStatus(is_anchor_imported=False, is_server_owner_initialized=False, is_server_code_initialized=False, software_token_init_status=TokenStatus.NOT_INITIALIZED)))
+    def test_status_uninitialized_server(self):
+        with XRDSSTTest() as app:
+            status_controller = StatusController()
+            status_controller.app = app
+            status_controller.load_config = (lambda: self.ss_config)
+            status_controller._default()
+
+            out, err = self.capsys.readouterr()
+
+            # Global status
+            assert status_controller.app._last_rendered[0][1][0].count('FAIL') == 1
+            assert status_controller.app._last_rendered[0][1][0].count('INTERNAL') == 1
+            assert status_controller.app._last_rendered[0][1][0].count('LAST') == 1
+            assert status_controller.app._last_rendered[0][1][0].count('NEXT') == 1
+
+            # Security server and its version
+            assert status_controller.app._last_rendered[0][1][1].count('longServerName') == 1
+            assert status_controller.app._last_rendered[0][1][1].count('6.25.0') == 1
+
+            # Roles granted to API user
+            assert status_controller.app._last_rendered[0][1][2].upper().count('ADMINISTRATOR') == 1
+            assert status_controller.app._last_rendered[0][1][2].upper().count('OFFICER') == 1
+
+            # Token status
+            assert status_controller.app._last_rendered[0][1][3].upper().count('TOKEN NOT_INITIALIZED') == 1
+
+            # Other columns not available
+            for col in range(4, 9):
+                assert '' == status_controller.app._last_rendered[0][1][col].strip()
+
+            with self.capsys.disabled():
+                sys.stdout.write(out)
+                sys.stderr.write(err)
+
+    @mock.patch.object(UserApi, 'get_user', (lambda x: User(username='api-key-N', permissions=[], roles=['ROLE_XROAD_SYSTEM_ADMINISTRATOR', 'ROLE_XROAD_SECURITY_OFFICER'])))
+    @mock.patch.object(SystemApi, 'system_version', (lambda x: Version(info="6.25.0")))
+    @mock.patch.object(DiagnosticsApi, 'get_global_conf_diagnostics', (lambda x: GlobalConfDiagnostics(status_class="OK", status_code="SUCCESS", prev_update_at=datetime.now(), next_update_at=datetime.now() + timedelta(minutes=5))))
+    @mock.patch.object(InitializationApi, 'get_initialization_status', (lambda x: InitializationStatus(is_anchor_imported=True, is_server_owner_initialized=True, is_server_code_initialized=True, software_token_init_status=TokenStatus.OK)))
+    @mock.patch.object(SecurityServersApi, 'get_security_servers', (lambda x, **kwargs: [
+        SecurityServer(id="TEST:GOV:8672:SSLONG", instance_id="TEST", member_class="GOV", server_address="4.2.2.1", server_code="SSLONG")
+    ]))
+    @mock.patch.object(SystemApi, 'get_configured_timestamping_services', (lambda x: [
+        TimestampingService(name="one tsa", url="https://one.tsa"),
+        TimestampingService(name="two tsa", url="https://two.tsa"),
+    ]))
+    @mock.patch.object(TokensApi, 'get_token', (lambda x, y: Token(
+        available=True, id="0", keys=[], logged_in=False, name="softToken-0",
+        possible_actions=[PossibleAction.LOGIN, PossibleAction.EDIT_FRIENDLY_NAME],
+        read_only=False, saved_to_configuration=True, status=TokenStatus.OK, type=TokenType.SOFTWARE))
+    )
+    def test_status_initialized_server(self):
+        with XRDSSTTest() as app:
+            status_controller = StatusController()
+            status_controller.app = app
+            status_controller.load_config = (lambda: self.ss_config)
+            status_controller._default()
+
+            out, err = self.capsys.readouterr()
+
+            # Global status
+            assert status_controller.app._last_rendered[0][1][0].count('OK') == 1
+            assert status_controller.app._last_rendered[0][1][0].count('SUCCESS') == 1
+            assert status_controller.app._last_rendered[0][1][0].count('LAST') == 1
+            assert status_controller.app._last_rendered[0][1][0].count('NEXT') == 1
+
+            # Security server and its version
+            assert status_controller.app._last_rendered[0][1][1].count('longServerName') == 1
+            assert status_controller.app._last_rendered[0][1][1].count('6.25.0') == 1
+
+            # Roles granted to API user
+            assert status_controller.app._last_rendered[0][1][2].upper().count('ADMINISTRATOR') == 1
+            assert status_controller.app._last_rendered[0][1][2].upper().count('OFFICER') == 1
+
+            # Initialization statuses
+            assert status_controller.app._last_rendered[0][1][3].count('ANCHOR INITIALIZED') == 1
+            assert status_controller.app._last_rendered[0][1][3].count('CODE INITIALIZED') == 1
+            assert status_controller.app._last_rendered[0][1][3].count('OWNER INITIALIZED') == 1
+            assert status_controller.app._last_rendered[0][1][3].count('TOKEN OK') == 1
+
+            # TSA list
+            assert status_controller.app._last_rendered[0][1][4].count('one tsa') == 1
+            assert status_controller.app._last_rendered[0][1][4].count('two tsa') == 1
+
+            # Token data
+            assert status_controller.app._last_rendered[0][1][5].count('ID 0') == 1
+            assert status_controller.app._last_rendered[0][1][5].count('softToken-0') == 1
+            assert status_controller.app._last_rendered[0][1][5].count('STATUS OK') == 1
+            assert status_controller.app._last_rendered[0][1][5].count('LOGIN NO') == 1
+
+            # Other columns not filled with given data
+            for col in range(6, 9):
+                assert '' == status_controller.app._last_rendered[0][1][col].strip()
+
+            with self.capsys.disabled():
+                sys.stdout.write(out)
+                sys.stderr.write(err)

--- a/tests/unit/test_xrdsst.py
+++ b/tests/unit/test_xrdsst.py
@@ -1,4 +1,5 @@
 from xrdsst.controllers.base import BaseController
+from xrdsst.core.util import default_sign_key_label, default_auth_key_label
 from xrdsst.main import opdep_init
 
 
@@ -15,12 +16,12 @@ def test_opdep_init_adds_app_opdep():
 
 def test_default_sign_key_label():
     security_server_config = {'name': 'ss-name1'}
-    assert 'ss-name1-default-sign-key' == BaseController.default_sign_key_label(security_server_config)
+    assert 'ss-name1-default-sign-key' == default_sign_key_label(security_server_config)
 
 
 def test_default_auth_key_label():
     security_server_config = {'name': 'ss-name2'}
-    assert 'ss-name2-default-auth-key' == BaseController.default_auth_key_label(security_server_config)
+    assert 'ss-name2-default-auth-key' == default_auth_key_label(security_server_config)
 
 
 def test_security_server_address_from_url():

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -4,7 +4,17 @@ import time
 from urllib.parse import urlparse
 import requests
 from xrdsst.controllers.base import BaseController
+from xrdsst.core.util import default_auth_key_label
 from xrdsst.models import ConnectionType
+
+
+class ObjectStruct:
+    def __init__(self, **entries): self.__dict__.update(entries)
+
+    def __eq__(self, other): return self.__dict__ == other.__dict__
+
+    def __ne__(self, other): return self.__dict__ != other.__dict__
+
 
 # Waits until boolean function returns True within number of retried delays or raises error
 def waitfor(boolf, delay, retries):
@@ -81,7 +91,7 @@ def find_test_ca_sign_url(conf_anchor_file_loc):
 # Check for auth cert registration update receival
 def auth_cert_registration_global_configuration_update_received(config):
     def registered_auth_key(key):
-        return BaseController.default_auth_key_label(config["security_server"][0]) == key['label'] and \
+        return default_auth_key_label(config["security_server"][0]) == key['label'] and \
                'REGISTERED' == key['certificates'][0]['status']
 
     result = requests.get(

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -127,7 +127,7 @@ class BaseController(Controller):
 
         if auto_log:
             if not logging.getLogger().handlers: # auto_log enabled due to errors, needs setting up
-                logging.basicConfig(filename=log_file_name, level=log_level, force=False, format=log_format)
+                logging.basicConfig(filename=log_file_name, level=log_level, format=log_format)
             exit_messages.append("Activities logged into '" + log_file_name + "'.")
             atexit.register(lambda: print(*exit_messages, sep='\n'))
 

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -69,7 +69,7 @@ class BaseController(Controller):
     # Render arguments differ for back-ends, one approach.
     def render(self, render_data):
         if self.is_output_tabulated():
-            self.app.render(render_data, headers="firstrow")
+            self.app.render(render_data, headers="firstrow", tablefmt="fancy_grid")
         else:
             self.app.render(render_data)
 
@@ -161,15 +161,6 @@ class BaseController(Controller):
     def log_info(message):
         logging.info(message)
         print(message)
-
-    # TODO: these are very useful, but they might be better off migrated into some utility from base controller
-    @staticmethod
-    def default_auth_key_label(security_server):
-        return security_server['name'] + '-default-auth-key'
-
-    @staticmethod
-    def default_sign_key_label(security_server):
-        return security_server['name'] + '-default-sign-key'
 
     @staticmethod
     def security_server_address(security_server):

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -115,7 +115,7 @@ class BaseController(Controller):
                 raise IsADirectoryError
             # 2nd condition allows for relative log file path spec
             if os.path.exists(os.path.dirname(log_file_name)) or not os.path.dirname(log_file_name):
-                logging.basicConfig(filename=log_file_name, level=log_level, force=False, format=log_format)
+                logging.basicConfig(filename=log_file_name, level=log_level, format=log_format)
         except IsADirectoryError:
             exit_messages.append("Log configuration referred to directory: '" + log_file_name + "'.")
             log_file_name = auto_log_file_name

--- a/xrdsst/controllers/cert.py
+++ b/xrdsst/controllers/cert.py
@@ -8,6 +8,7 @@ from xrdsst.api import KeysApi
 from xrdsst.api.token_certificates_api import TokenCertificatesApi
 from xrdsst.controllers.base import BaseController
 from xrdsst.core.api_util import remote_get_token
+from xrdsst.core.util import default_auth_key_label, default_sign_key_label
 from xrdsst.models import SecurityServerAddress, CsrFormat
 from xrdsst.api_client.api_client import ApiClient
 from xrdsst.resources.texts import texts
@@ -148,8 +149,8 @@ class CertController(BaseController):
 
     def remote_download_csrs(self, ss_configuration, security_server):
         key_labels = {
-            'auth': BaseController.default_auth_key_label(security_server),
-            'sign': BaseController.default_sign_key_label(security_server)
+            'auth': default_auth_key_label(security_server),
+            'sign': default_sign_key_label(security_server)
         }
 
         token = remote_get_token(ss_configuration, security_server)
@@ -197,7 +198,7 @@ class CertController(BaseController):
     def find_actionable_auth_certificate(ss_configuration, security_server, cert_action):
         token = remote_get_token(ss_configuration, security_server)
         # Find the authentication certificate by conventional name
-        auth_key_label = BaseController.default_auth_key_label(security_server)
+        auth_key_label = default_auth_key_label(security_server)
         auth_keys = list(filter(lambda key: key.label == auth_key_label, token.keys))
         found_auth_key_count = len(auth_keys)
         if found_auth_key_count == 0:

--- a/xrdsst/controllers/client.py
+++ b/xrdsst/controllers/client.py
@@ -22,6 +22,7 @@ class ClientController(BaseController):
     def register(self):
         self.register_client(self.load_config())
 
+    # This operation can (at least sometimes) also be performed when global status is FAIL.
     def add_client(self, configuration):
         self.init_logging(configuration)
         for security_server in configuration["security_server"]:
@@ -30,6 +31,7 @@ class ClientController(BaseController):
             for client in security_server["clients"]:
                 self.remote_add_client(ss_configuration, client)
 
+    # This operation fails when global status is not up to date.
     def register_client(self, configuration):
         self.init_logging(configuration)
         for security_server in configuration["security_server"]:

--- a/xrdsst/controllers/status.py
+++ b/xrdsst/controllers/status.py
@@ -1,0 +1,199 @@
+from cement import ex
+
+from xrdsst.core.api_util import status_global, status_system_version, status_roles, \
+    status_server_initialization, status_timestamping, status_token, status_token_keys_and_certs, \
+    StatusRoles, StatusVersion, StatusGlobal, StatusServerInitialization, StatusServerTimestamping, StatusToken, \
+    StatusKeys, StatusCerts, StatusCsrs
+from xrdsst.controllers.base import BaseController
+from xrdsst.resources.texts import texts
+
+
+class ServerStatus:
+    security_server_name: str = None
+    roles_status: StatusRoles = None
+    version_status: StatusVersion
+    global_status: StatusGlobal
+    server_init_status: StatusServerInitialization
+    timestamping_status: [StatusServerTimestamping]
+    token_status: StatusToken
+    status_keys: StatusKeys
+    status_csrs: StatusCsrs
+    status_certs: StatusCerts
+
+    def __init__(self, security_server_name: str = None, roles_status: StatusRoles = None,
+                 version_status=StatusVersion(), global_status=StatusGlobal(),
+                 server_init_status= StatusServerInitialization(),
+                 timestamping_status=[], token_status=StatusToken(),
+                 status_keys=StatusKeys(), status_csrs=StatusCsrs(), status_certs=StatusCerts()):
+        self.security_server_name = security_server_name
+        self.roles_status = roles_status
+        self.version_status = version_status
+        self.global_status = global_status
+        self.server_init_status = server_init_status
+        self.timestamping_status = timestamping_status
+        self.token_status = token_status
+        self.status_keys = status_keys
+        self.status_csrs = status_csrs
+        self.status_certs = status_certs
+
+
+class StatusListMapper:
+    @staticmethod
+    def iso_datetime_str(dt):
+        return dt.strftime(dt.isoformat()) if dt else None
+
+    @staticmethod
+    def server_id(server_init_status):
+        return server_init_status.id_ if (server_init_status.has_server_code and server_init_status.has_server_owner) else None
+
+    @staticmethod
+    def headers():
+        return ['GLOBAL', 'SERVER', 'ROLES', 'INIT', 'TSAS', 'TOKEN', 'KEYS', 'CSRS', 'CERTS']
+
+    @staticmethod
+    def as_list(server_status: ServerStatus):
+        if not server_status.roles_status.permitted:
+            result = ['' for _ in range(7)]
+            result.insert(1, server_status.security_server_name)
+            result.insert(2, server_status.roles_status.to_status_str())
+            return result
+        return [
+            server_status.global_status.to_status_str(),
+            server_status.security_server_name + '\n' +
+            server_status.version_status.to_status_str() + '\n' +
+            next((sid for sid in [StatusListMapper.server_id(server_status.server_init_status)] if sid is not None), ''),
+            server_status.roles_status.to_status_str(),
+            server_status.server_init_status.to_status_str(),
+            '\n'.join(map(lambda tss: tss.name, server_status.timestamping_status)),
+            server_status.token_status.to_status_str(),
+            server_status.status_keys.to_status_str(),
+            server_status.status_csrs.to_status_str(),
+            server_status.status_certs.to_status_str()
+        ]
+
+    @staticmethod
+    def as_object(server_status):
+        return {
+            'security_server': {
+                'name': server_status.security_server_name,
+                'version': server_status.version_status.version,
+                'id': next((sid for sid in [StatusListMapper.server_id(server_status.server_init_status)] if sid is not None), ''),
+                'global_status': {
+                    'class': server_status.global_status.class_,
+                    'code': server_status.global_status.code,
+                    'updated': StatusListMapper.iso_datetime_str(server_status.global_status.updated),
+                    'refresh': StatusListMapper.iso_datetime_str(server_status.global_status.refresh)
+                },
+                'roles': server_status.roles_status.roles,
+                'initialization': {
+                    'has_anchor': server_status.server_init_status.has_anchor,
+                    'has_server_code': server_status.server_init_status.has_server_code,
+                    'server_code': server_status.server_init_status.server_code,
+                    'has_server_owner': server_status.server_init_status.has_server_owner,
+                    'server_owner': server_status.server_init_status.server_owner,
+                    'token_init_status': server_status.server_init_status.token_init_status
+                },
+                'tsa_list': list(map(lambda x: {'name': x.name, 'url': x.url}, server_status.timestamping_status)),
+                'token': {
+                    'id': server_status.token_status.id,
+                    'name': server_status.token_status.name,
+                    'status': server_status.token_status.status,
+                    'logged_in': server_status.token_status.logged_in
+                },
+                'keys': {
+                    'key_count': server_status.status_keys.key_count,
+                    'sign_key_count': server_status.status_keys.sign_key_count,
+                    'auth_key_count': server_status.status_keys.auth_key_count,
+                    'has_sign_key': server_status.status_keys.has_sign_key,
+                    'has_toolkit_sign_key': server_status.status_keys.has_toolkit_sign_key,
+                    'toolkit_sign_key_id': server_status.status_keys.toolkit_sign_key_id,
+                    'has_auth_key': server_status.status_keys.has_auth_key,
+                    'has_toolkit_auth_key': server_status.status_keys.has_toolkit_auth_key,
+                    'toolkit_auth_key_id': server_status.status_keys.toolkit_auth_key_id,
+                },
+                'csrs': {
+                    'sign_csr_count': server_status.status_csrs.sign_csr_count,
+                    'auth_csr_count': server_status.status_csrs.auth_csr_count,
+                    'has_toolkit_sign_csr': server_status.status_csrs.has_toolkit_sign_csr,
+                    'has_sign_csr': server_status.status_csrs.has_sign_csr,
+                    'has_toolkit_auth_csr': server_status.status_csrs.has_toolkit_auth_csr,
+                    'has_auth_csr': server_status.status_csrs.has_auth_csr
+                },
+                'certificates' : {
+                    'has_toolkit_sign_cert': server_status.status_certs.has_toolkit_sign_cert,
+                    'toolkit_sign_cert_hash': server_status.status_certs.toolkit_sign_cert_hash,
+                    'has_sign_cert': server_status.status_certs.has_sign_cert,
+                    'has_toolkit_auth_cert': server_status.status_certs.has_toolkit_auth_cert,
+                    'toolkit_auth_cert_hash': server_status.status_certs.toolkit_auth_cert_hash,
+                    'has_auth_cert': server_status.status_certs.has_auth_cert,
+                    'has_registered_auth_cert': server_status.status_certs.has_registered_auth_cert
+                }
+            }
+        }
+
+
+class StatusController(BaseController):
+    class Meta:
+        label = 'status'
+        stacked_on = 'base'
+        stacked_type = 'nested'
+        description = texts['status.controller.description']
+
+    @ex(help='status', hide=True)
+    def _default(self):
+        self._status(self.load_config())
+
+    # Since this is read-only operation, do not log anything, only console output
+    def _status(self, configuration):
+        render_data = []
+        servers = []
+        if configuration.get("security_server"):
+            for security_server in configuration["security_server"]:
+                ss_configuration = self.initialize_basic_config_values(security_server, configuration)
+                servers.append(self.remote_status(ss_configuration, security_server))
+
+        if self.is_output_tabulated():
+            render_data = [StatusListMapper.headers()]
+            render_data.extend(map(StatusListMapper.as_list, servers))
+        else:
+            render_data.extend(map(StatusListMapper.as_object, servers))
+
+        self.render(render_data)
+        if self.is_output_tabulated() and not configuration.get("security_server"):
+            print("No security servers defined.")
+
+    @staticmethod
+    def remote_status(ss_configuration, security_server):
+        roles_status = status_roles(ss_configuration)
+        if not roles_status.permitted:
+            return ServerStatus(
+                security_server_name=security_server["name"],
+                roles_status=roles_status
+            )
+
+        version_status = status_system_version(ss_configuration)
+        glob_status = status_global(ss_configuration)
+        server_init_status = status_server_initialization(ss_configuration)
+
+        # If server has not been initialized, the following calls return errors a'la "Server conf is not initialized!"
+        if server_init_status.has_anchor:
+            timestamping_status = status_timestamping(ss_configuration)
+            token_status = status_token(ss_configuration, security_server)
+            status_keys, status_csrs, status_certs = status_token_keys_and_certs(ss_configuration, security_server)
+        else:
+            timestamping_status = []
+            token_status = StatusToken()
+            status_keys, status_csrs, status_certs = (StatusKeys(), StatusCsrs(), StatusCerts())
+
+        return ServerStatus(
+            security_server_name=security_server["name"],
+            roles_status=roles_status,
+            version_status=version_status,
+            global_status=glob_status,
+            server_init_status=server_init_status,
+            timestamping_status=timestamping_status,
+            token_status=token_status,
+            status_keys=status_keys,
+            status_csrs=status_csrs,
+            status_certs=status_certs
+        )

--- a/xrdsst/controllers/status.py
+++ b/xrdsst/controllers/status.py
@@ -141,7 +141,7 @@ class StatusController(BaseController):
 
     @ex(help='status', hide=True)
     def _default(self):
-        self._status(self.load_config())
+        return self._status(self.load_config())  # Returned for status comparisons in tests only
 
     # Since this is read-only operation, do not log anything, only console output
     def _status(self, configuration):
@@ -161,6 +161,8 @@ class StatusController(BaseController):
         self.render(render_data)
         if self.is_output_tabulated() and not configuration.get("security_server"):
             print("No security servers defined.")
+
+        return servers
 
     @staticmethod
     def remote_status(ss_configuration, security_server):

--- a/xrdsst/controllers/token.py
+++ b/xrdsst/controllers/token.py
@@ -4,6 +4,7 @@ from xrdsst.api.security_servers_api import SecurityServersApi
 from xrdsst.api.certificate_authorities_api import CertificateAuthoritiesApi
 from xrdsst.core.api_util import remote_get_token
 from xrdsst.controllers.base import BaseController
+from xrdsst.core.util import default_auth_key_label, default_sign_key_label
 from xrdsst.models import CsrGenerate, KeyUsageType, CsrFormat, KeyLabelWithCsrGenerate
 from xrdsst.rest.rest import ApiException
 from xrdsst.api_client.api_client import ApiClient
@@ -132,8 +133,8 @@ class TokenController(BaseController):
         dn_common_name = security_server['owner_member_code']
         dn_org = security_server['owner_dn_org']
 
-        auth_key_label = BaseController.default_auth_key_label(security_server)
-        sign_key_label = BaseController.default_sign_key_label(security_server)
+        auth_key_label = default_auth_key_label(security_server)
+        sign_key_label = default_sign_key_label(security_server)
 
         try:
             ssi = remote_get_security_server_instance(ss_configuration)

--- a/xrdsst/core/api_util.py
+++ b/xrdsst/core/api_util.py
@@ -44,7 +44,7 @@ class StatusVersion:
             f'StatusVersion(version="{self.version}")'
 
     def to_status_str(self):
-        return ('VER ' + self.version)
+        return 'VER ' + self.version
 
 
 class StatusRoles:
@@ -66,18 +66,18 @@ class StatusRoles:
 
 class StatusAnchor:
     has_anchor: bool = False
-    hash: str = None
+    hash_: str = None
     created_at: datetime = None
 
-    def __init__(self, has_anchor: bool = False, hash: str = None, created_at: datetime = None):
+    def __init__(self, has_anchor: bool = False, hash_: str = None, created_at: datetime = None):
         self.has_anchor = has_anchor
-        self.hash = hash
+        self.hash_ = hash
         self.created_at = created_at
 
     def __repr__(self):
         return \
             f'StatusAnchor(has_anchor={self.has_anchor},' \
-            f'hash="{self.hash}",' \
+            f'hash_="{self.hash_}",' \
             f'created_at={self.created_at})'
 
 
@@ -131,6 +131,14 @@ class StatusServerTimestamping:
             f'StatusServerTimestamping(name="{self.name}",' \
             f'url="{self.url}")'
 
+    def __eq__(self, other):
+        if isinstance(other, StatusServerTimestamping):
+            return \
+                self.name == other.name and \
+                self.url == other.url
+
+        return False
+
 
 class StatusToken:
     id: str = None
@@ -138,8 +146,8 @@ class StatusToken:
     status: str = None
     logged_in: bool = False
 
-    def __init__(self, id: str = None, name: str = None, status: str = None, logged_in: bool = False):
-        self.id = id
+    def __init__(self, id_: str = None, name: str = None, status: str = None, logged_in: bool = False):
+        self.id = id_
         self.name = name
         self.status = status
         self.logged_in = logged_in
@@ -328,7 +336,7 @@ def status_anchor(ss_configuration):
     anchor = system_api.get_anchor()
     return StatusAnchor(
         has_anchor=True,
-        hash=anchor.hash,
+        hash_=anchor.hash,
         created_at=anchor.created_at
     )
 
@@ -374,7 +382,7 @@ def status_timestamping(ss_configuration):
 def status_token(ss_configuration, security_server):
     token = remote_get_token(ss_configuration, security_server)
     return StatusToken(
-        id=token.id,
+        id_=token.id,
         name=token.name,
         status=token.status,
         logged_in=token.logged_in

--- a/xrdsst/core/api_util.py
+++ b/xrdsst/core/api_util.py
@@ -1,5 +1,279 @@
-from xrdsst.api import TokensApi
+from datetime import datetime
+
+from xrdsst.api import TokensApi, DiagnosticsApi, SystemApi, UserApi, InitializationApi, SecurityServersApi
 from xrdsst.api_client.api_client import ApiClient
+from xrdsst.core.util import default_auth_key_label, default_sign_key_label
+from xrdsst.models import KeyUsageType, CertificateStatus
+from xrdsst.rest.rest import ApiException
+
+
+class StatusGlobal:
+    class_: str = None
+    code: str = None
+    updated: datetime = None
+    refresh: datetime = None
+
+    def __init__(self, class_: str = None, code: str = None, updated: datetime = None, refresh: datetime = None):
+        self.class_ = class_
+        self.code = code
+        self.updated = updated
+        self.refresh = refresh
+
+    def __repr__(self):
+        return \
+            f'StatusGlobal(class_="{self.class_}",' \
+            f'code="{self.code}",' \
+            f'updated="{self.updated}",' \
+            f'refresh="{self.refresh}")'
+
+    def to_status_str(self):
+        return self.class_ + \
+               ' (' + self.code.replace('ERROR_CODE_', '') + ')\n' + \
+               'LAST ' + self.updated.strftime("%H%M%S %m%d") + "\n" + \
+               'NEXT ' + self.refresh.strftime("%H%M%S %m%d")
+
+
+class StatusVersion:
+    version: str = None
+
+    def __init__(self, version: str = None):
+        self.version = version
+
+    def __repr__(self):
+        return \
+            f'StatusVersion(version="{self.version}")'
+
+    def to_status_str(self):
+        return ('VER ' + self.version)
+
+
+class StatusRoles:
+    permitted: bool = False
+    roles: [str] = None
+
+    def __init__(self, permitted: bool = False, roles: [str] = None):
+        self.permitted = permitted
+        self.roles = roles
+
+    def __repr__(self):
+        return \
+            f'StatusRoles(permitted={self.permitted})' \
+            f'StatusRoles(roles={self.roles})'
+
+    def to_status_str(self):
+        return '\n'.join(list(map(lambda s: s.replace("ROLE_XROAD_", "").replace("_", " ").lower().title(), self.roles))) if self.permitted else "NO ACCESS"
+
+
+class StatusAnchor:
+    has_anchor: bool = False
+    hash: str = None
+    created_at: datetime = None
+
+    def __init__(self, has_anchor: bool = False, hash: str = None, created_at: datetime = None):
+        self.has_anchor = has_anchor
+        self.hash = hash
+        self.created_at = created_at
+
+    def __repr__(self):
+        return \
+            f'StatusAnchor(has_anchor={self.has_anchor},' \
+            f'hash="{self.hash}",' \
+            f'created_at={self.created_at})'
+
+
+class StatusServerInitialization:
+    id_: str = None
+    has_anchor: bool = False
+    has_server_code: bool = False
+    server_code: str = None
+    has_server_owner: bool = False
+    server_owner: str = None
+    token_init_status: str = None
+
+    def __init__(self, id_: str = None, has_anchor: bool = False, has_server_code: bool = False, server_code: str = None,
+                 has_server_owner: bool = False, server_owner: str = None, token_init_status: str = None):
+        self.id_ = id_
+        self.has_anchor = has_anchor
+        self.has_server_code = has_server_code
+        self.server_code = server_code
+        self.has_server_owner = has_server_owner
+        self.server_owner = server_owner
+        self.token_init_status = token_init_status
+
+    def __repr__(self):
+        return \
+            f'StatusServerInitialization(id_="{self.id_}",' \
+            f'has_anchor={self.has_anchor},' \
+            f'has_server_code={self.has_server_code},' \
+            f'server_code="{self.server_code}",' \
+            f'has_server_owner={self.has_server_owner},' \
+            f'server_owner="{self.server_owner}",' \
+            f'token_init_status={self.token_init_status})'
+
+    def to_status_str(self):
+        return \
+            ('ANCHOR INITIALIZED\n' if self.has_anchor else ('' + '\n')) + \
+            ('CODE INITIALIZED\n' if self.has_server_code else ('' + '\n')) + \
+            ('OWNER INITIALIZED\n' if self.has_server_owner else '' + '\n') + \
+            ('TOKEN' + ' ' + self.token_init_status) if self.token_init_status else '' + '\n'
+
+
+class StatusServerTimestamping:
+    name: str = None
+    url: str = None
+
+    def __init__(self, name: str = None, url: str = None):
+        self.name = name
+        self.url = url
+
+    def __repr__(self):
+        return \
+            f'StatusServerTimestamping(name="{self.name}",' \
+            f'url="{self.url}")'
+
+
+class StatusToken:
+    id: str = None
+    name: str = None
+    status: str = None
+    logged_in: bool = False
+
+    def __init__(self, id: str = None, name: str = None, status: str = None, logged_in: bool = False):
+        self.id = id
+        self.name = name
+        self.status = status
+        self.logged_in = logged_in
+
+    def __repr__(self):
+        return \
+            f'StatusToken(id={self.id},' \
+            f'name="{self.name}",' \
+            f'status="{self.status}",' \
+            f'logged_in={self.logged_in})'
+
+    def to_status_str(self):
+        if not self.id:  # No token initialized, probably anchorless security server or some severe error.
+            return ''
+
+        return \
+            '  ID ' + self.id + '\n' + \
+            self.name + '\n' + \
+            "STATUS " + self.status + '\n' + \
+            "LOGIN " + ("YES" if self.logged_in else "NO")
+
+
+class StatusKeys:
+    key_count: int = 0
+    sign_key_count: int = 0
+    auth_key_count: int = 0
+    has_toolkit_sign_key: bool = False
+    toolkit_sign_key_id: str = None
+    has_sign_key: bool = False
+
+    has_toolkit_auth_key: bool = False
+    toolkit_auth_key_id: str = None
+    has_auth_key: bool = False
+
+    def __init__(self, key_count: int = 0, sign_key_count: int = 0, auth_key_count: int = 0,
+                 has_toolkit_sign_key: bool = False, toolkit_sign_key_id: str = None, has_sign_key: bool = False,
+                 has_toolkit_auth_key: bool = False, toolkit_auth_key_id: str = None, has_auth_key: bool = False):
+        self.key_count = key_count
+        self.sign_key_count = sign_key_count
+        self.auth_key_count = auth_key_count
+        self.has_toolkit_sign_key = has_toolkit_sign_key
+        self.toolkit_sign_key_id = toolkit_sign_key_id
+        self.has_sign_key = has_sign_key
+        self.has_toolkit_auth_key = has_toolkit_auth_key
+        self.toolkit_auth_key_id = toolkit_auth_key_id
+        self.has_auth_key = has_auth_key
+
+    def __repr__(self):
+        return \
+            f'StatusKeys(key_count={self.key_count},' \
+            f'sign_key_count={self.sign_key_count},' \
+            f'auth_key_count={self.auth_key_count},' \
+            f'has_toolkit_sign_key={self.has_toolkit_sign_key},' \
+            f'toolkit_sign_key_id="{self.toolkit_sign_key_id}",' \
+            f'has_sign_key={self.has_sign_key},' \
+            f'has_toolkit_auth_key={self.has_toolkit_auth_key},' \
+            f'toolkit_auth_key_id="{self.toolkit_auth_key_id}",' \
+            f'has_auth_key={self.has_auth_key})'
+
+    def to_status_str(self):
+        return \
+            (("SIGN" + ("*" if not self.has_toolkit_sign_key else '') + ' (' + str(self.sign_key_count) + ')') if self.has_sign_key else "") + '\n' + \
+            (("AUTH" + ("*" if not self.has_toolkit_auth_key else '') + ' (' + str(self.auth_key_count) + ')') if self.has_auth_key else "") + '\n' + \
+            str(self.key_count) + " KEYS" if self.key_count > 0 else ''  # Might not be == (sign_key_count + auth_key_count), esp. on hardware tokens.
+
+
+class StatusCsrs:
+    sign_csr_count: int = 0
+    auth_csr_count: int = 0
+    has_toolkit_sign_csr: bool = False
+    has_sign_csr: bool = False
+    has_toolkit_auth_csr: bool = False
+    has_auth_csr: bool = False
+
+    def __init__(self, sign_csr_count: int = 0, auth_csr_count: int = 0, has_toolkit_sign_csr: bool = False,
+                 has_sign_csr: bool = False, has_toolkit_auth_csr: bool = False, has_auth_csr: bool = False):
+        self.sign_csr_count = sign_csr_count
+        self.auth_csr_count = auth_csr_count
+        self.has_toolkit_sign_csr = has_toolkit_sign_csr
+        self.has_sign_csr = has_sign_csr
+        self.has_toolkit_auth_csr = has_toolkit_auth_csr
+        self.has_auth_csr = has_auth_csr
+
+    def __repr__(self):
+        return \
+            f'StatusCsrs(sign_csr_count={self.sign_csr_count},' \
+            f'auth_csr_count={self.auth_csr_count},' \
+            f'has_toolkit_sign_csr={self.has_toolkit_sign_csr},' \
+            f'has_sign_csr={self.has_sign_csr},' \
+            f'has_toolkit_auth_csr={self.has_toolkit_auth_csr},' \
+            f'has_auth_csr={self.has_auth_csr})'
+
+    def to_status_str(self):
+        return \
+            (("SIGN" + ("*" if not self.has_toolkit_sign_csr else '') + ' (' + str(self.sign_csr_count) + ')') if self.has_sign_csr else "") + '\n' + \
+            (("AUTH" + ("*" if not self.has_toolkit_auth_csr else '') + ' (' + str(self.auth_csr_count) + ')') if self.has_auth_csr else "") + '\n' + \
+            str(self.sign_csr_count + self.auth_csr_count) + " CSRS" if (self.sign_csr_count + self.auth_csr_count > 0) else ''
+
+
+class StatusCerts:
+    has_toolkit_sign_cert: bool = False
+    toolkit_sign_cert_hash: str = None
+    has_sign_cert: bool = False
+
+    has_toolkit_auth_cert: bool = False
+    toolkit_auth_cert_hash: str = None
+    has_auth_cert: bool = False
+    has_registered_auth_cert: bool = False
+
+    def __init__(self, has_toolkit_sign_cert: bool = False, toolkit_sign_cert_hash: str = None,
+                 has_sign_cert: bool = False, has_toolkit_auth_cert: bool = False, toolkit_auth_cert_hash: str = None,
+                 has_auth_cert: bool = False, has_registered_auth_cert: bool = False):
+        self.has_toolkit_sign_cert = has_toolkit_sign_cert
+        self.toolkit_sign_cert_hash = toolkit_sign_cert_hash
+        self.has_sign_cert = has_sign_cert
+        self.has_toolkit_auth_cert = has_toolkit_auth_cert
+        self.toolkit_auth_cert_hash = toolkit_auth_cert_hash
+        self.has_auth_cert = has_auth_cert
+        self.has_registered_auth_cert = has_registered_auth_cert
+
+    def __repr__(self):
+        return \
+            f'StatusCerts(has_toolkit_sign_cert={self.has_toolkit_sign_cert},' \
+            f'toolkit_sign_cert_hash="{self.toolkit_sign_cert_hash}",' \
+            f'has_sign_cert={self.has_sign_cert},' \
+            f'has_toolkit_auth_cert={self.has_toolkit_auth_cert},' \
+            f'toolkit_auth_cert_hash="{self.toolkit_auth_cert_hash}",' \
+            f'has_auth_cert={self.has_auth_cert},' \
+            f'has_registered_auth_cert={self.has_registered_auth_cert})'
+
+    def to_status_str(self):
+        return \
+            (("SIGN" + ("*" if not self.has_toolkit_sign_cert else '')) if self.has_sign_cert else "") + '\n' + \
+            (("AUTH" + ("*" if not self.has_toolkit_sign_cert else '')) if self.has_sign_cert else "") + '\n'
 
 
 def remote_get_token(ss_configuration, security_server):
@@ -7,3 +281,191 @@ def remote_get_token(ss_configuration, security_server):
     token_api = TokensApi(ApiClient(ss_configuration))
     token = token_api.get_token(token_id)
     return token
+
+
+# Returns 'global status' of X-Road according to security servers knowledge
+def status_global(ss_configuration):
+    diagnostics_api = DiagnosticsApi(ApiClient(ss_configuration))
+    glob_conf_diag = diagnostics_api.get_global_conf_diagnostics()
+
+    glob_status = StatusGlobal(
+        class_=glob_conf_diag.status_class,
+        code=glob_conf_diag.status_code,
+        updated=glob_conf_diag.prev_update_at,
+        refresh=glob_conf_diag.next_update_at
+    )
+    return glob_status
+
+
+# Returns security server version reported by server itself
+def status_system_version(ss_configuration):
+    system_api = SystemApi(ApiClient(ss_configuration))
+    sys_ver = system_api.system_version()
+    return StatusVersion(sys_ver.info)
+
+
+# Returns roles of the user doing the API call in human readable form
+def status_roles(ss_configuration):
+    user_api = UserApi(ApiClient(ss_configuration))
+    try:
+        user = user_api.get_user()
+    except ApiException as aex:
+        if aex.status == 401 or aex.status == 403:
+            return StatusRoles(permitted=False, roles=[])
+    return StatusRoles(permitted=True, roles=user.roles)
+
+
+# Returns security server anchor information, if available
+def status_anchor(ss_configuration):
+    initialization_api = InitializationApi(ApiClient(ss_configuration))
+    system_api = SystemApi(ApiClient(ss_configuration))
+
+    init_response = initialization_api.get_initialization_status()
+
+    if not init_response.is_anchor_imported:
+        return StatusAnchor(has_anchor=False)
+
+    anchor = system_api.get_anchor()
+    return StatusAnchor(
+        has_anchor=True,
+        hash=anchor.hash,
+        created_at=anchor.created_at
+    )
+
+
+# Returns security server basic initialization settings
+def status_server_initialization(ss_configuration):
+    initialization_api = InitializationApi(ApiClient(ss_configuration))
+    security_servers_api = SecurityServersApi(ApiClient(ss_configuration))
+
+    init_response = initialization_api.get_initialization_status()
+
+    ssi = StatusServerInitialization(
+        has_anchor=init_response.is_anchor_imported,
+        has_server_code=init_response.is_server_code_initialized,
+        has_server_owner=init_response.is_server_owner_initialized,
+        token_init_status=init_response.software_token_init_status
+        # Later conditional fill for: server_code, server_owner, token_init_status
+    )
+
+    if init_response.is_anchor_imported:
+        ss_api_response = security_servers_api.get_security_servers(current_server=True)
+        sec_server_details = ss_api_response.pop()
+
+        ssi.server_code = sec_server_details.server_code if init_response.is_server_code_initialized else None
+        ssi.server_owner = sec_server_details.member_code if init_response.is_server_owner_initialized else None
+        ssi.id_ = sec_server_details.id if init_response.is_server_owner_initialized and init_response.is_server_code_initialized else None
+        ssi.token_init_status = init_response.software_token_init_status
+
+    return ssi
+
+
+# Returns /configured/ (active) timestamping services for the security server
+def status_timestamping(ss_configuration):
+    system_api = SystemApi(ApiClient(ss_configuration))
+    ts_list_response = system_api.get_configured_timestamping_services()
+    return list(map(lambda tss: StatusServerTimestamping(
+        name=tss.name,
+        url=tss.url
+    ), ts_list_response))
+
+
+# Returns token status information for security server token specified in the configuration file.
+def status_token(ss_configuration, security_server):
+    token = remote_get_token(ss_configuration, security_server)
+    return StatusToken(
+        id=token.id,
+        name=token.name,
+        status=token.status,
+        logged_in=token.logged_in
+    )
+
+
+# Returns triple of (key, csr, cert) statuses for security server token specified in the configuration file.
+def status_token_keys_and_certs(ss_configuration, security_server):
+    # From among multiple certificates, returns first that is closest to being in REGISTERED
+    def best_cert(certs):
+        return next(
+            (crt for crt in certs if CertificateStatus.REGISTERED == crt.status),
+            next(
+                (crt for crt in certs if CertificateStatus.REGISTRATION_IN_PROGRESS == crt.status),
+                next(
+                    (crt for crt in certs if CertificateStatus.SAVED == crt.status),
+                    next(
+                        (crt for crt in certs if CertificateStatus.DELETION_IN_PROGRESS != crt.status),
+                        certs[0]
+                    )
+                )
+            )
+        )
+
+    token = remote_get_token(ss_configuration, security_server)
+    token_key_count = len(token.keys)
+
+    toolkit_auth_key_label = default_auth_key_label(security_server)
+    auth_keys = list(filter(lambda key: key.usage == KeyUsageType.AUTHENTICATION, token.keys))
+    toolkit_auth_keys = list(filter(lambda key: key.label == toolkit_auth_key_label, auth_keys))
+    has_toolkit_auth_key = toolkit_auth_keys and len(toolkit_auth_keys) == 1
+
+    toolkit_sign_key_label = default_sign_key_label(security_server)
+    sign_keys = list(filter(lambda key: key.usage == KeyUsageType.SIGNING, token.keys))
+    toolkit_sign_keys = list(filter(lambda key: key.label == toolkit_sign_key_label, sign_keys))
+    has_toolkit_sign_key = len(toolkit_sign_keys) == 1
+
+    # KEYS
+
+    status_keys = StatusKeys(
+        key_count=token_key_count,
+        sign_key_count=len(sign_keys),
+        auth_key_count=len(auth_keys),
+        has_toolkit_sign_key=has_toolkit_sign_key,
+        toolkit_sign_key_id=toolkit_sign_keys[0].id if has_toolkit_sign_key else None,
+        has_sign_key=len(sign_keys) > 0,
+
+        has_toolkit_auth_key=has_toolkit_auth_key,
+        toolkit_auth_key_id=toolkit_auth_keys[0].id if has_toolkit_auth_key else None,
+        has_auth_key=len(auth_keys) > 0
+    )
+
+    # CSRS
+
+    auth_keys_with_csrs = list(filter(lambda key: len(key.certificate_signing_requests) > 0, auth_keys))
+    toolkit_auth_keys_with_csrs = list(filter(lambda key: len(key.certificate_signing_requests) > 0, toolkit_auth_keys))
+    sign_keys_with_csrs = list(filter(lambda key: len(key.certificate_signing_requests) > 0, sign_keys))
+    toolkit_sign_keys_with_csrs = list(filter(lambda key: len(key.certificate_signing_requests) > 0, toolkit_sign_keys))
+
+    status_csrs = StatusCsrs(
+        sign_csr_count=len(sum(map(lambda key: key.certificate_signing_requests, sign_keys_with_csrs), [])),
+        auth_csr_count=len(sum(map(lambda key: key.certificate_signing_requests, auth_keys_with_csrs), [])),
+        has_toolkit_sign_csr=len(toolkit_sign_keys_with_csrs) > 0,
+        has_sign_csr=len(sign_keys_with_csrs) > 0,
+        has_toolkit_auth_csr=len(toolkit_auth_keys_with_csrs) > 0,
+        has_auth_csr=len(auth_keys_with_csrs) > 0
+    )
+
+    # Tried so hard, came so far, CERTIFICATES!
+
+    certs_of_auth_keys = sum(map(lambda key: key.certificates, auth_keys), [])
+    certs_of_sign_keys = sum(map(lambda key: key.certificates, sign_keys), [])
+
+    registered_auth_key_certs = list(
+        filter(lambda cert: CertificateStatus.REGISTERED == cert.status, certs_of_auth_keys))
+
+    has_toolkit_sign_cert: bool = (has_toolkit_sign_key and len(toolkit_sign_keys[0].certificates) > 0)
+    toolkit_sign_cert = best_cert(toolkit_sign_keys[0].certificates) if has_toolkit_sign_cert else None
+
+    has_toolkit_auth_cert: bool = (has_toolkit_auth_key and len(toolkit_auth_keys[0].certificates) > 0)
+    toolkit_auth_cert = best_cert(toolkit_auth_keys[0].certificates) if has_toolkit_auth_cert else None
+
+    status_certs = StatusCerts(
+        has_sign_cert=len(certs_of_sign_keys) > 0,
+        has_toolkit_sign_cert=has_toolkit_sign_cert,
+        toolkit_sign_cert_hash=toolkit_sign_cert.certificate_details.hash if toolkit_sign_cert else None,
+
+        has_auth_cert=len(certs_of_auth_keys) > 0,
+        has_toolkit_auth_cert=has_toolkit_auth_cert,
+        toolkit_auth_cert_hash=toolkit_auth_cert.certificate_details.hash if toolkit_auth_cert else None,
+        has_registered_auth_cert=len(registered_auth_key_certs) > 0
+    )
+
+    return status_keys, status_csrs, status_certs

--- a/xrdsst/core/util.py
+++ b/xrdsst/core/util.py
@@ -1,0 +1,8 @@
+# Returns toolkit default AUTHENTICATION key label, given security server configuration
+def default_auth_key_label(security_server):
+    return security_server['name'] + '-default-auth-key'
+
+
+# Returns toolkit default SIGNING key label, given security server configuration
+def default_sign_key_label(security_server):
+    return security_server['name'] + '-default-sign-key'

--- a/xrdsst/core/version.py
+++ b/xrdsst/core/version.py
@@ -1,7 +1,7 @@
 """Module for getting project version"""
 from cement.utils.version import get_version as cement_get_version
 
-CURRENT_VERSION = "0.2.1-alpha.0"
+CURRENT_VERSION = "0.2.2-alpha.0"
 
 
 def convert_version(version_str):

--- a/xrdsst/main.py
+++ b/xrdsst/main.py
@@ -14,6 +14,7 @@ from xrdsst.controllers.base import BaseController
 from xrdsst.controllers.cert import CertController
 from xrdsst.controllers.client import ClientController
 from xrdsst.controllers.service import ServiceController
+from xrdsst.controllers.status import StatusController
 from xrdsst.controllers.timestamp import TimestampController
 from xrdsst.controllers.init import InitServerController
 from xrdsst.controllers.token import TokenController
@@ -137,7 +138,7 @@ class XRDSST(App):
         output_handler = 'tabulate'
 
         # register handlers
-        handlers = [BaseController, ClientController, CertController, TimestampController,
+        handlers = [BaseController, StatusController, ClientController, CertController, TimestampController,
                     TokenController, InitServerController, AutoController, ServiceController]
 
 

--- a/xrdsst/resources/texts.py
+++ b/xrdsst/resources/texts.py
@@ -8,4 +8,5 @@ texts = {
     'timestamp.controller.description': 'Commands for performing timestamping service operations.',
     'token.controller.description': 'Commands for performing token operations.',
     'service.controller.description': 'Commands for performing service operations.',
+    'status.controller.description': 'Query for server configuration statuses.'
 }


### PR DESCRIPTION
This PR has the following:
  * core/api_util.py
    - status classes for representing server configuration status and status of different server operations 
    - API status query methods that can be used per-operation when dependent operations have verified to have been completed, or unconditionally in succession, in which case they must be grouped according to the server initialization status: timestamping, token, token key, token key csr, token key cert operations API call DO return 500 ``{"status":500,"error":{"code":"core.MalformedServerConf","metadata":["Server conf is not initialized!"]}`` if the initialization has not been completed.
    - status classes should are mostly sufficient to correctly traverse the dependent operation graph depending on the server-side configuration, and accordingly, to present end-user with the context (in much shorter form than this shown)
  * controllers/status.py
    - single console operation 'status' that returns the /core/ configuration status -- this does not include clients or services, the output is already quite long and these things probably do deserve their own listing methods that can both give better overview and be more detailed
    - the status is expected to work in all conditions where security server is reachable at all and API key access has been provider
    - information output in json is bit more detailed than for console, to be more useful for possible scripting (e.g. hashes of toolkit-generated certs, if available) 
