### PR TITLE
Autoerrors of sstoolkit-49  → 0.2.3-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.3-alpha.0] - 2021-02-22
 - Autoconfiguration to be sequential per-security server.
-- Defined operation completion criterias.
+- Defined operation completion criteria.
 - Operations made aware of operational context.
 - Configuration file validated on global level (keys) and operation level (required keys, value sanity)
 - Autoconfiguration stops after operation that could not be completed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.3-alpha.0] - 2021-02-22
+- Autoconfiguration to be sequential per-security server.
+- Defined operation completion criterias.
+- Operations made aware of operational context.
+- Configuration file validated on global level (keys) and operation level (required keys, value sanity)
+- Autoconfiguration stops after operation that could not be completed
+- Autoconfiguration shows base operation statuses when ended / stopped.
+
 ## [0.2.2-alpha.0] - 2021-02-03
 - Add examination of configured server statuses with ``xrdsst status``
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.2-alpha.0
+current_version = 0.2.3-alpha.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)\.(?P<build>\d+))?

--- a/tests/end_to_end/tests.py
+++ b/tests/end_to_end/tests.py
@@ -1,14 +1,13 @@
 import os
 import subprocess
 import sys
-import time
 import unittest
 from unittest import mock
 
 import urllib3
 
 from tests.util.test_util import find_test_ca_sign_url, perform_test_ca_sign, get_client, get_service_description, \
-    assert_server_statuses_transitioned
+    assert_server_statuses_transitioned, auth_cert_registration_global_configuration_update_received, waitfor
 from xrdsst.controllers.auto import AutoController
 from xrdsst.controllers.base import BaseController
 from xrdsst.controllers.cert import CertController
@@ -26,17 +25,20 @@ class EndToEndTest(unittest.TestCase):
     config = None
 
     def setUp(self):
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-        idx = 0
-        for arg in sys.argv:
-            idx += 1
-            if arg == "-c":
-                self.config_file = sys.argv[idx]
-        base = BaseController()
-        self.config = base.load_config(baseconfig=self.config_file)
-        for security_server in self.config["security_server"]:
-            api_key = base.get_api_key(self.config, security_server)
-            self.create_api_key(api_key)
+        with XRDSSTTest() as app:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+            idx = 0
+            for arg in sys.argv:
+                idx += 1
+                if arg == "-c":
+                    self.config_file = sys.argv[idx]
+            base = BaseController()
+            base.app = app
+            self.config = base.load_config(baseconfig=self.config_file)
+            for security_server in self.config["security_server"]:
+                api_key = base.get_api_key(self.config, security_server)
+                self.create_api_key(api_key)
 
     def tearDown(self):
         self.revoke_api_key()
@@ -69,32 +71,36 @@ class EndToEndTest(unittest.TestCase):
                 assert len(response[0].url) > 0
 
     def step_token_login(self):
-        token_controller = TokenController()
-        for security_server in self.config["security_server"]:
-            configuration = token_controller.initialize_basic_config_values(security_server, self.config)
-            response = token_controller.remote_get_tokens(configuration)
-            assert len(response) > 0
-            assert response[0].logged_in is False
-            token_controller.remote_token_login(configuration, security_server)
-            response = token_controller.remote_get_tokens(configuration)
-            assert len(response) > 0
-            assert response[0].logged_in is True
+        with XRDSSTTest() as app:
+            token_controller = TokenController()
+            token_controller.app = app
+            for security_server in self.config["security_server"]:
+                configuration = token_controller.initialize_basic_config_values(security_server, self.config)
+                response = token_controller.remote_get_tokens(configuration)
+                assert len(response) > 0
+                assert response[0].logged_in is False
+                token_controller.remote_token_login(configuration, security_server)
+                response = token_controller.remote_get_tokens(configuration)
+                assert len(response) > 0
+                assert response[0].logged_in is True
 
     def step_token_init_keys(self):
-        token_controller = TokenController()
-        for security_server in self.config["security_server"]:
-            configuration = token_controller.initialize_basic_config_values(security_server, self.config)
-            response = token_controller.remote_get_tokens(configuration)
-            assert len(response) > 0
-            assert len(response[0].keys) == 0
-            token_controller.remote_token_add_keys_with_csrs(configuration, security_server)
-            response = token_controller.remote_get_tokens(configuration)
-            assert len(response) > 0
-            assert len(response[0].keys) == 2
-            auth_key_label = security_server['name'] + '-default-auth-key'
-            sign_key_label = security_server['name'] + '-default-sign-key'
-            assert str(response[0].keys[0].label) == auth_key_label
-            assert str(response[0].keys[1].label) == sign_key_label
+        with XRDSSTTest() as app:
+            token_controller = TokenController()
+            token_controller.app = app
+            for security_server in self.config["security_server"]:
+                configuration = token_controller.initialize_basic_config_values(security_server, self.config)
+                response = token_controller.remote_get_tokens(configuration)
+                assert len(response) > 0
+                assert len(response[0].keys) == 0
+                token_controller.remote_token_add_keys_with_csrs(configuration, security_server)
+                response = token_controller.remote_get_tokens(configuration)
+                assert len(response) > 0
+                assert len(response[0].keys) == 2
+                auth_key_label = security_server['name'] + '-default-auth-key'
+                sign_key_label = security_server['name'] + '-default-sign-key'
+                assert str(response[0].keys[0].label) == auth_key_label
+                assert str(response[0].keys[1].label) == sign_key_label
 
     def step_cert_download_csrs(self):
         with XRDSSTTest() as app:
@@ -233,12 +239,11 @@ class EndToEndTest(unittest.TestCase):
         signed_certs = self.step_acquire_certs(downloaded_csrs)
         self.apply_cert_config(signed_certs)
         self.step_cert_import()
-        self.step_cert_import()
         self.step_cert_register()
         self.step_cert_activate()
 
         # Wait for global configuration status updates
-        time.sleep(120)
+        waitfor(lambda: auth_cert_registration_global_configuration_update_received(self.config), 1, 300)
 
         self.step_subsystem_add_client()
         self.step_subsystem_register()

--- a/tests/integration/integration_base.py
+++ b/tests/integration/integration_base.py
@@ -1,0 +1,152 @@
+import json
+import os
+import subprocess
+import time
+import unittest
+from unittest import mock
+
+import docker
+import git
+
+from definitions import ROOT_DIR
+from tests.util.test_util import find_test_ca_sign_url, perform_test_ca_sign
+from xrdsst.controllers.auto import AutoController
+from xrdsst.controllers.base import BaseController
+from xrdsst.controllers.cert import CertController
+from xrdsst.controllers.status import StatusController
+from xrdsst.main import XRDSSTTest
+
+
+# Make less of many evils and use one abstract test class base for encapsulating rather involved Docker setup.
+class IntegrationTestBase(unittest.TestCase):
+    __test__ = False
+    configuration_anchor = "tests/resources/configuration-anchor.xml"
+    credentials = "xrd:secret"
+    git_repo = 'https://github.com/nordic-institute/X-Road.git'
+    local_folder = os.path.join(ROOT_DIR, "tests/integration/X-Road")
+    branch_name = 'develop'
+    docker_folder = local_folder + '/Docker/securityserver'
+    image = 'xroad-security-server:latest'
+    url = 'https://localhost:4000/api/v1/api-keys'
+    roles = '[\"XROAD_SYSTEM_ADMINISTRATOR\",\"XROAD_SERVICE_ADMINISTRATOR\", \"XROAD_SECURITY_OFFICER\", \"XROAD_REGISTRATION_OFFICER\"]'
+    header = 'Content-Type: application/json'
+    max_retries = 300
+    retry_wait = 1  # in seconds
+    name = None
+    config = None
+
+    def init_config(self):
+        self.config = {
+            'logging': [{'file': '/var/log/xrdsst_test.log', 'level': 'INFO'}],
+            'api_key': [{'url': self.url,
+                         'key': 'key',
+                         'roles': json.loads(self.roles)}],
+            'security_server':
+                [{'name': 'ss',
+                  'url': 'https://CONTAINER_HOST:4000/api/v1',
+                  'api_key': 'X-Road-apikey token=a2e9dea1-de53-4ebc-a750-6be6461d91f0',
+                  'configuration_anchor': os.path.join(ROOT_DIR, self.configuration_anchor),
+                  'owner_dn_country': 'EE',
+                  'owner_dn_org': 'ORG',
+                  'owner_member_class': 'GOV',
+                  'owner_member_code': '1234',
+                  'security_server_code': 'SS',
+                  'software_token_id': 0,
+                  'software_token_pin': '1234',
+                  'clients': [{
+                      'member_class': 'GOV',
+                      'member_code': '1234',
+                      'subsystem_code': 'BUS',
+                      'connection_type': 'HTTP',
+                      'service_descriptions': [{
+                          'url': 'https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator-gradle-plugin/samples/local-spec/petstore-v3.0.yaml',
+                          'rest_service_code': 'Petstore',
+                          'type': 'OPENAPI3'
+                      }
+                      ]
+                  }]
+                  }]
+        }
+        self.name = self.config["security_server"][0]["name"]
+        return self.config
+
+    def load_config(self):
+        return self.config
+
+    def set_api_key(self, api_key):
+        self.config["security_server"][0]["api_key"] = 'X-Road-apikey token=' + api_key
+
+    def set_ip_url(self, ip_address):
+        local_url = self.config["security_server"][0]["url"]
+        container_ip_url = local_url.replace("CONTAINER_HOST", ip_address)
+        self.config["security_server"][0]["url"] = container_ip_url
+
+    def setUp(self):
+        self.init_config()
+        self.clean_docker()
+        self.clone_repo()
+        client = docker.from_env()
+        self.build_image(client)
+        self.run_container(client)
+
+        # Wait for functional networking to be started up, with side effect of configuration update.
+        container_ip = ''
+        count = 0
+        while not container_ip and count < self.max_retries:
+            time.sleep(self.retry_wait)
+            count += 1
+            container_ip = client.containers.list(filters={"name": self.name})[0].attrs['NetworkSettings']['IPAddress']
+        if count >= self.max_retries and not container_ip:
+            raise Exception("Unable to acquire network address of the container '" + self.name + "'.")
+
+        self.set_ip_url(container_ip)
+        self.create_api_key(client)
+
+    def tearDown(self):
+        subprocess.call("rm -rf " + self.local_folder + "/", shell=True)
+        self.clean_docker()
+
+    def clone_repo(self):
+        if not os.path.exists(self.local_folder):
+            git.Repo.clone_from(self.git_repo, self.local_folder, branch=self.branch_name)
+
+    def build_image(self, client):
+        images = client.images.list(name=self.image)
+        if len(images) == 0:
+            client.images.build(path=self.docker_folder, tag=self.image)
+
+    def run_container(self, client):
+        containers = client.containers.list(filters={"name": self.name})
+        if len(containers) == 0:
+            client.containers.run(detach=True, name=self.name, image=self.image, ports={'4000/tcp': 8000})
+        elif len(containers) == 1:
+            if containers[0].status != 'running':
+                containers[0].restart()
+        else:
+            raise Exception("Encountered multiple containers named '" + self.name + "', no action taken.")
+
+    def create_api_key(self, client):
+        containers = client.containers.list(filters={"name": self.name})
+        for container in containers:
+            if container.name == self.name:
+                retries = 0
+                while retries <= self.max_retries:
+                    cmd = "curl -X POST -u " + self.credentials + " --silent " + self.url + " --data \'" + self.roles + \
+                          "\'" + " --header \"" + self.header + "\" -k"
+                    result = container.exec_run(cmd, stdout=True, stderr=True, demux=False)
+                    if len(result.output) > 0:
+                        json_data = json.loads(result.output)
+                        self.set_api_key(json_data["key"])
+                        break
+                    time.sleep(self.retry_wait)
+                    retries += 1
+
+    def clean_docker(self):
+        client = docker.from_env()
+        containers = client.containers.list(filters={"name": self.name})
+        for container in containers:
+            if container.name == self.name:
+                subprocess.run("docker rm -f " + self.name, shell=True, check=False)
+        images = client.images.list(name=self.image)
+        if len(images) != 0:
+            client.images.remove(image=self.image, force=True)

--- a/tests/integration/integration_ops.py
+++ b/tests/integration/integration_ops.py
@@ -1,0 +1,73 @@
+from unittest import mock
+
+from tests.util.test_util import perform_test_ca_sign, find_test_ca_sign_url
+from xrdsst.controllers.auto import AutoController
+from xrdsst.controllers.base import BaseController
+from xrdsst.controllers.cert import CertController
+from xrdsst.controllers.status import StatusController
+from xrdsst.main import XRDSSTTest
+
+
+# More frequent and/or general integration test operations.
+class IntegrationOpBase:
+    #
+    # Certificate operations
+    #
+    def step_cert_download_csrs(self):
+        with XRDSSTTest() as app:
+            cert_controller = CertController()
+            cert_controller.app = app
+            cert_controller.load_config = (lambda: self.config)
+            result = cert_controller.download_csrs()
+            assert len(result) == 2
+            assert result[0].fs_loc != result[1].fs_loc
+
+            return [
+                ('sign', next(csr.fs_loc for csr in result if csr.key_type == 'SIGN')),
+                ('auth', next(csr.fs_loc for csr in result if csr.key_type == 'AUTH')),
+            ]
+
+    def step_acquire_certs(self, downloaded_csrs):
+        tca_sign_url = find_test_ca_sign_url(self.config['security_server'][0]['configuration_anchor'])
+        cert_files = []
+        for down_csr in downloaded_csrs:
+            cert = perform_test_ca_sign(tca_sign_url, down_csr[1], down_csr[0])
+            cert_file = down_csr[1] + ".signed.pem"
+            cert_files.append(cert_file)
+            with open(cert_file, "w") as out_cert:
+                out_cert.write(cert)
+
+        return cert_files
+
+    def apply_cert_config(self, signed_certs):
+        self.config['security_server'][0]['certificates'] = signed_certs
+
+    #
+    # STATUS query
+    #
+    def query_status(self):
+        with XRDSSTTest() as app:
+            status_controller = StatusController()
+            status_controller.app = app
+            status_controller.load_config = (lambda: self.config)
+
+            servers = status_controller._default()
+
+            # Must not throw exception, must produce output, test with global status only -- should be ALWAYS present
+            # in the configuration that integration test will be run, even when it is still failing as security server
+            # has only recently been started up.
+            assert status_controller.app._last_rendered[0][1][0].count('LAST') == 1
+            assert status_controller.app._last_rendered[0][1][0].count('NEXT') == 1
+
+            return servers
+
+    #
+    # Autoconfiguration invocation
+    #
+    def step_autoconf(self):
+        with XRDSSTTest() as app:
+            with mock.patch.object(BaseController, 'load_config',  (lambda x, y=None: self.config)):
+                auto_controller = AutoController()
+                auto_controller.app = app
+                auto_controller._default()
+

--- a/tests/integration/test_xrdsst.py
+++ b/tests/integration/test_xrdsst.py
@@ -1,25 +1,15 @@
-import json
-import os
-import subprocess
-import time
-import unittest
-from unittest import mock
-
-import docker
-import git
 import urllib3
 
-from definitions import ROOT_DIR
-from tests.util.test_util import get_service_description, find_test_ca_sign_url, perform_test_ca_sign, \
-    assert_server_statuses_transitioned
+from tests.integration.integration_base import IntegrationTestBase
+from tests.integration.integration_ops import IntegrationOpBase
 from tests.util.test_util import get_client, auth_cert_registration_global_configuration_update_received, waitfor
-from xrdsst.controllers.auto import AutoController
+from tests.util.test_util import get_service_description, assert_server_statuses_transitioned
 from xrdsst.controllers.base import BaseController
 from xrdsst.controllers.cert import CertController
 from xrdsst.controllers.client import ClientController
 from xrdsst.controllers.init import InitServerController
 from xrdsst.controllers.service import ServiceController
-from xrdsst.controllers.status import StatusController, ServerStatus
+from xrdsst.controllers.status import ServerStatus
 from xrdsst.controllers.timestamp import TimestampController
 from xrdsst.controllers.token import TokenController
 from xrdsst.main import XRDSSTTest
@@ -44,153 +34,8 @@ def server_statuses_equal(sl1: [ServerStatus], sl2: [ServerStatus]):
     return True
 
 
-class TestXRDSST(unittest.TestCase):
-    configuration_anchor = "tests/resources/configuration-anchor.xml"
-    credentials = "xrd:secret"
-    git_repo = 'https://github.com/nordic-institute/X-Road.git'
-    local_folder = os.path.join(ROOT_DIR, "tests/integration/X-Road")
-    branch_name = 'develop'
-    docker_folder = local_folder + '/Docker/securityserver'
-    image = 'xroad-security-server:latest'
-    url = 'https://localhost:4000/api/v1/api-keys'
-    roles = '[\"XROAD_SYSTEM_ADMINISTRATOR\",\"XROAD_SERVICE_ADMINISTRATOR\", \"XROAD_SECURITY_OFFICER\", \"XROAD_REGISTRATION_OFFICER\"]'
-    header = 'Content-Type: application/json'
-    max_retries = 300
-    retry_wait = 1  # in seconds
-    name = None
-    config = None
-
-    def init_config(self):
-        self.config = {
-            'logging': [{'file': '/var/log/xrdsst_test.log', 'level': 'INFO'}],
-            'api_key': [{'url': self.url,
-                         'key': 'key',
-                         'roles': json.loads(self.roles)}],
-            'security_server':
-                [{'name': 'ss',
-                  'url': 'https://CONTAINER_HOST:4000/api/v1',
-                  'api_key': 'X-Road-apikey token=a2e9dea1-de53-4ebc-a750-6be6461d91f0',
-                  'configuration_anchor': os.path.join(ROOT_DIR, self.configuration_anchor),
-                  'owner_dn_country': 'EE',
-                  'owner_dn_org': 'ORG',
-                  'owner_member_class': 'GOV',
-                  'owner_member_code': '1234',
-                  'security_server_code': 'SS',
-                  'software_token_id': 0,
-                  'software_token_pin': '1234',
-                  'clients': [{
-                      'member_class': 'GOV',
-                      'member_code': '1234',
-                      'subsystem_code': 'BUS',
-                      'connection_type': 'HTTP',
-                      'service_descriptions': [{
-                          'url': 'https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator-gradle-plugin/samples/local-spec/petstore-v3.0.yaml',
-                          'rest_service_code': 'Petstore',
-                          'type': 'OPENAPI3'
-                      }
-                      ]
-                  }]
-                  }]
-        }
-        self.name = self.config["security_server"][0]["name"]
-        return self.config
-
-    def load_config(self):
-        return self.config
-
-    def set_api_key(self, api_key):
-        self.config["security_server"][0]["api_key"] = 'X-Road-apikey token=' + api_key
-
-    def set_ip_url(self, ip_address):
-        local_url = self.config["security_server"][0]["url"]
-        container_ip_url = local_url.replace("CONTAINER_HOST", ip_address)
-        self.config["security_server"][0]["url"] = container_ip_url
-
-    def setUp(self):
-        self.init_config()
-        self.clean_docker()
-        self.clone_repo()
-        client = docker.from_env()
-        self.build_image(client)
-        self.run_container(client)
-
-        # Wait for functional networking to be started up, with side effect of configuration update.
-        container_ip = ''
-        count = 0
-        while not container_ip and count < self.max_retries:
-            time.sleep(self.retry_wait)
-            count += 1
-            container_ip = client.containers.list(filters={"name": self.name})[0].attrs['NetworkSettings']['IPAddress']
-        if count >= self.max_retries and not container_ip:
-            raise Exception("Unable to acquire network address of the container '" + self.name + "'.")
-
-        self.set_ip_url(container_ip)
-        self.create_api_key(client)
-
-    def tearDown(self):
-        subprocess.call("rm -rf " + self.local_folder + "/", shell=True)
-        self.clean_docker()
-
-    def clone_repo(self):
-        if not os.path.exists(self.local_folder):
-            git.Repo.clone_from(self.git_repo, self.local_folder, branch=self.branch_name)
-
-    def build_image(self, client):
-        images = client.images.list(name=self.image)
-        if len(images) == 0:
-            client.images.build(path=self.docker_folder, tag=self.image)
-
-    def run_container(self, client):
-        containers = client.containers.list(filters={"name": self.name})
-        if len(containers) == 0:
-            client.containers.run(detach=True, name=self.name, image=self.image, ports={'4000/tcp': 8000})
-        elif len(containers) == 1:
-            if containers[0].status != 'running':
-                containers[0].restart()
-        else:
-            raise Exception("Encountered multiple containers named '" + self.name + "', no action taken.")
-
-    def create_api_key(self, client):
-        containers = client.containers.list(filters={"name": self.name})
-        for container in containers:
-            if container.name == self.name:
-                retries = 0
-                while retries <= self.max_retries:
-                    cmd = "curl -X POST -u " + self.credentials + " --silent " + self.url + " --data \'" + self.roles + \
-                          "\'" + " --header \"" + self.header + "\" -k"
-                    result = container.exec_run(cmd, stdout=True, stderr=True, demux=False)
-                    if len(result.output) > 0:
-                        json_data = json.loads(result.output)
-                        self.set_api_key(json_data["key"])
-                        break
-                    time.sleep(self.retry_wait)
-                    retries += 1
-
-    def clean_docker(self):
-        client = docker.from_env()
-        containers = client.containers.list(filters={"name": self.name})
-        for container in containers:
-            if container.name == self.name:
-                subprocess.run("docker rm -f " + self.name, shell=True, check=False)
-        images = client.images.list(name=self.image)
-        if len(images) != 0:
-            client.images.remove(image=self.image, force=True)
-
-    def query_status(self):
-        with XRDSSTTest() as app:
-            status_controller = StatusController()
-            status_controller.app = app
-            status_controller.load_config = (lambda: self.config)
-
-            servers = status_controller._default()
-
-            # Must not throw exception, must produce output, test with global status only -- should be ALWAYS present
-            # in the configuration that integration test will be run, even when it is still failing as security server
-            # has only recently been started up.
-            assert status_controller.app._last_rendered[0][1][0].count('LAST') == 1
-            assert status_controller.app._last_rendered[0][1][0].count('NEXT') == 1
-
-            return servers
+class TestXRDSST(IntegrationTestBase, IntegrationOpBase):
+    __test__ = True
 
     def step_init(self):
         base = BaseController()
@@ -212,43 +57,18 @@ class TestXRDSST(unittest.TestCase):
             timestamp_controller.init()
 
     def step_token_login(self):
-        token_controller = TokenController()
-        token_controller.load_config = (lambda: self.config)
-        token_controller.login()
+        with XRDSSTTest() as app:
+            token_controller = TokenController()
+            token_controller.app = app
+            token_controller.load_config = (lambda: self.config)
+            token_controller.login()
 
     def step_token_init_keys(self):
-        token_controller = TokenController()
-        token_controller.load_config = (lambda: self.config)
-        token_controller.init_keys()
-
-    def step_cert_download_csrs(self):
         with XRDSSTTest() as app:
-            cert_controller = CertController()
-            cert_controller.app = app
-            cert_controller.load_config = (lambda: self.config)
-            result = cert_controller.download_csrs()
-            assert len(result) == 2
-            assert result[0].fs_loc != result[1].fs_loc
-
-            return [
-                ('sign', next(csr.fs_loc for csr in result if csr.key_type == 'SIGN')),
-                ('auth', next(csr.fs_loc for csr in result if csr.key_type == 'AUTH')),
-            ]
-
-    def step_acquire_certs(self, downloaded_csrs):
-        tca_sign_url = find_test_ca_sign_url(self.config['security_server'][0]['configuration_anchor'])
-        cert_files = []
-        for down_csr in downloaded_csrs:
-            cert = perform_test_ca_sign(tca_sign_url, down_csr[1], down_csr[0])
-            cert_file = down_csr[1] + ".signed.pem"
-            cert_files.append(cert_file)
-            with open(cert_file, "w") as out_cert:
-                out_cert.write(cert)
-
-        return cert_files
-
-    def apply_cert_config(self, signed_certs):
-        self.config['security_server'][0]['certificates'] = signed_certs
+            token_controller = TokenController()
+            token_controller.app = app
+            token_controller.load_config = (lambda: self.config)
+            token_controller.init_keys()
 
     def step_cert_import(self):
         with XRDSSTTest() as app:
@@ -303,13 +123,6 @@ class TestXRDSST(unittest.TestCase):
             service_description = get_service_description(self.config, client_id)
             assert service_description["disabled"] is False
 
-    def step_autoconf(self):
-        with XRDSSTTest() as app:
-            with mock.patch.object(BaseController, 'load_config',  (lambda x, y=None: self.config)):
-                auto_controller = AutoController()
-                auto_controller.app = app
-                auto_controller._default()
-
     def test_run_configuration(self):
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         # Uninitialized security server can already have functioning API interface and status query must function
@@ -332,9 +145,6 @@ class TestXRDSST(unittest.TestCase):
         signed_certs = self.step_acquire_certs(downloaded_csrs)
 
         self.apply_cert_config(signed_certs)
-        self.query_status()
-
-        self.step_cert_import()
         self.query_status()
 
         self.step_cert_import()
@@ -375,5 +185,3 @@ class TestXRDSST(unittest.TestCase):
 
         auto_reconfigured_servers_after = self.query_status()
         assert server_statuses_equal(configured_servers_at_end, auto_reconfigured_servers_after)
-
-

--- a/tests/integration/test_xrdsst_auto.py
+++ b/tests/integration/test_xrdsst_auto.py
@@ -1,0 +1,105 @@
+import urllib3
+
+from tests.integration.integration_base import IntegrationTestBase
+from tests.integration.integration_ops import IntegrationOpBase
+from tests.util.test_util import waitfor, auth_cert_registration_global_configuration_update_received, \
+    assert_server_statuses_transitioned, api_GET
+
+
+def assert_clients_transitioned(api_url, api_key):
+    clients = api_GET(api_url, "clients", api_key)
+
+    assert (2 == len(clients))
+    assert (2 == len([x for x in clients if x['status'] == 'REGISTERED']))
+    others = [x for x in clients if not x.get('subsystem_code', None)]
+    subsystems = [x for x in clients if x.get('subsystem_code', None)]
+    assert (1 == len(others))
+    assert (1 == len(subsystems))
+
+    assert (others[0]['owner'] is True)
+    owner = others[0]
+    sub = subsystems[0]
+
+    assert (owner['has_valid_local_sign_cert'] is True)
+    assert (owner['id'] == 'DEV:GOV:1234')  # This DEV prefix unfortunately does depend on central server.
+    assert (owner['instance_id'] == 'DEV')
+    assert (owner['member_class'] == 'GOV')
+    assert (owner['member_code'] == '1234')
+    assert (owner['member_name'] == 'ORG')
+    assert (owner['member_class'] == 'GOV')
+    # Registration, ownership asserted already
+
+    assert (sub['has_valid_local_sign_cert'] is True)
+    assert (sub['connection_type'] == 'HTTP')
+    assert (sub['id'] == 'DEV:GOV:1234:BUS')  # This DEV prefix unfortunately does depend on central server.
+    assert (sub['instance_id'] == 'DEV')
+    assert (sub['member_class'] == 'GOV')
+    assert (sub['member_code'] == '1234')
+    assert (sub['member_name'] == 'ORG')
+    assert (sub['owner'] is False)
+    assert (sub['subsystem_code'] == 'BUS')
+    # Registration asserted already
+
+
+def assert_client_service_descs_transitioned(api_url, api_key):
+    client_service_descs = api_GET(api_url, "clients/DEV:GOV:1234:BUS/service-descriptions", api_key)
+
+    assert (1 == len(client_service_descs))
+
+    csds = client_service_descs[0]
+    assert (1 == len(csds['services']))
+    assert (csds['client_id'] == 'DEV:GOV:1234:BUS')
+    assert (csds['disabled'] is False)
+    assert (csds['type'] == 'OPENAPI3')
+    assert (csds['url'] == 'https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator-gradle-plugin/samples/local-spec/petstore-v3.0.yaml')
+
+
+    sd = csds['services'][0]
+    assert (0 < len(sd['endpoints']))
+    assert (sd['full_service_code'] == 'Petstore')
+    assert (sd['service_code'] == 'Petstore')
+    assert (sd['id'] == 'DEV:GOV:1234:BUS:Petstore')
+    # Skip 'ssl_auth' & 'timeout'
+
+
+def assert_non_status_ops_transitioned(api_url, api_key):
+    assert_clients_transitioned(api_url, api_key)
+    assert_client_service_descs_transitioned(api_url, api_key)
+
+
+class TestXrdsstAuto(IntegrationTestBase, IntegrationOpBase):
+    __test__ = True
+
+    def test_run_auto_configuration(self):
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        # Uninitialized security server can already have functioning API interface and status query must function
+        unconfigured_servers_at_start = self.query_status()
+
+        # Expected to run until the certificates that are not there
+        self.step_autoconf()
+
+        # Get signed certificates
+        downloaded_csrs = self.step_cert_download_csrs()
+        signed_certs = self.step_acquire_certs(downloaded_csrs)
+
+        # Modify config to have certificates
+        self.apply_cert_config(signed_certs)
+
+        # Expected to import certificates, but not get further straight away, since registration globally is time-consuming.
+        self.step_autoconf()
+
+        # Wait for global configuration status updates
+        waitfor(lambda: auth_cert_registration_global_configuration_update_received(self.config), self.retry_wait, self.max_retries)
+        self.query_status()
+
+        # Now that registered auth cert is globally accepted, should proceed with everything else to successful end.
+        self.step_autoconf()
+
+        configured_servers_at_end = self.query_status()
+        assert_server_statuses_transitioned(unconfigured_servers_at_start, configured_servers_at_end)
+
+        # Verify non-base operation transitions
+        assert_non_status_ops_transitioned(
+            self.config["security_server"][0]["url"],
+            self.config["security_server"][0]["api_key"]
+        )

--- a/tests/unit/test_auto.py
+++ b/tests/unit/test_auto.py
@@ -1,11 +1,17 @@
+import sys
 import unittest
 from unittest import mock
 
-from tests.util.test_util import ObjectStruct
+import pytest
+
+from tests.util.test_util import ObjectStruct, StatusTestData
 from xrdsst.controllers.base import BaseController
 from xrdsst.controllers.auto import AutoController
 from xrdsst.controllers.cert import CertController
+from xrdsst.controllers.client import ClientController
 from xrdsst.controllers.init import InitServerController
+from xrdsst.controllers.service import ServiceController
+from xrdsst.controllers.status import StatusController
 from xrdsst.controllers.timestamp import TimestampController
 from xrdsst.controllers.token import TokenController
 from xrdsst.main import XRDSSTTest
@@ -19,11 +25,20 @@ class TestAuto(unittest.TestCase):
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
-              'api_key': 'X-Road-apikey token=api-key',
+              'api_key': 'X-Road-apikey token=66666666-8000-4011-a000-333336633333'
               }]}
+
+    @pytest.fixture(autouse=True)
+    def capsys(self, capsys):
+        self.capsys = capsys
 
     @mock.patch.object(XRDSSTTest, 'pargs', ObjectStruct(configfile=BaseController.config_file))
     @mock.patch.object(BaseController, 'load_config', (lambda x, y=None: TestAuto.ss_config))
+    @mock.patch.object(StatusController, '_default', (lambda x: StatusTestData.server_status_essentials_complete))  # Double mock!
+    @mock.patch.object(ServiceController, 'enable_description')
+    @mock.patch.object(ServiceController, 'add_description')
+    @mock.patch.object(ClientController, 'register')
+    @mock.patch.object(ClientController, 'add')
     @mock.patch.object(CertController, 'activate')
     @mock.patch.object(CertController, 'register')
     @mock.patch.object(CertController, 'import_')
@@ -31,10 +46,14 @@ class TestAuto(unittest.TestCase):
     @mock.patch.object(TokenController, 'login')
     @mock.patch.object(TimestampController, 'init')
     @mock.patch.object(InitServerController, '_default')
-    def test_autoconfig(self, init_mock, timestamp_init_mock, token_login_mock, token_key_init_mock, cert_import_mock, cert_register_mock, cert_activate_mock):
+    def test_autoconfig(self,
+                        init_mock, timestamp_init_mock, token_login_mock, token_key_init_mock,
+                        cert_import_mock, cert_register_mock, cert_activate_mock,
+                        client_add_mock, client_register_mock, service_desc_add_mock, service_desc_enable_mock):
         with XRDSSTTest() as app:
             auto_controller = AutoController()
             auto_controller.app = app
+            auto_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)  # Double mock!
             auto_controller._default()
 
             init_mock.assert_called_once()
@@ -44,3 +63,35 @@ class TestAuto(unittest.TestCase):
             cert_import_mock.assert_called_once()
             cert_register_mock.assert_called_once()
             cert_activate_mock.assert_called_once()
+            client_add_mock.assert_called_once()
+            client_register_mock.assert_called_once()
+            service_desc_add_mock.assert_called_once()
+            service_desc_enable_mock.assert_called_once()
+
+    @mock.patch.object(XRDSSTTest, 'pargs', ObjectStruct(configfile=BaseController.config_file))
+    @mock.patch.object(BaseController, 'load_config', (lambda x, y=None: TestAuto.ss_config))
+    @mock.patch.object(StatusController, '_default', (lambda x: StatusTestData.server_status_essentials_complete_token_logged_out()))  # Double mock!
+    @mock.patch.object(TokenController, 'init_keys')
+    @mock.patch.object(TokenController, 'login')
+    @mock.patch.object(TimestampController, 'init')
+    @mock.patch.object(InitServerController, '_default')
+    def test_autoconfig_token_login_fails(self,
+                        init_mock, timestamp_init_mock, token_login_mock, token_initkey_mock):
+        with XRDSSTTest() as app:
+            auto_controller = AutoController()
+            auto_controller.app = app
+            auto_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete_token_logged_out())  # Double mock!
+            auto_controller._default()
+
+            init_mock.assert_called_once()
+            timestamp_init_mock.assert_called_once()
+            token_login_mock.assert_called_once()
+            token_initkey_mock.assert_not_called()
+
+            out, err = self.capsys.readouterr()
+            assert 1 == out.count("completion was NOT detected")
+            assert 1 == out.count("Next AUTO operation would have been ['token init-keys'].")
+
+            with self.capsys.disabled():
+                sys.stdout.write(out)
+                sys.stderr.write(err)

--- a/tests/unit/test_auto.py
+++ b/tests/unit/test_auto.py
@@ -16,6 +16,7 @@ from xrdsst.controllers.timestamp import TimestampController
 from xrdsst.controllers.token import TokenController
 from xrdsst.main import XRDSSTTest
 
+
 class TestAuto(unittest.TestCase):
     ss_config = {
         'api_key': [{'url': 'https://localhost:4000/api/v1/api-keys',

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -1,5 +1,9 @@
 import os
+import sys
+import tempfile
 import unittest
+
+import pytest
 import yaml
 
 from pathlib import Path
@@ -9,11 +13,12 @@ from unittest.mock import patch
 from definitions import ROOT_DIR
 from xrdsst.configuration.configuration import Configuration
 from xrdsst.controllers.base import BaseController
+from xrdsst.core.util import convert_swagger_enum
+from xrdsst.main import XRDSSTTest
 from xrdsst.models import ConnectionType
 
 
 class TestBaseController(unittest.TestCase):
-
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     _ss_config = {
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
@@ -29,6 +34,10 @@ class TestBaseController(unittest.TestCase):
               'security_server_code': 'SS',
               'software_token_pin': '1234'}]}
 
+    @pytest.fixture(autouse=True)
+    def capsys(self, capsys):
+        self.capsys = capsys
+
     def get_ss_config(self):
         return self._ss_config
 
@@ -39,22 +48,233 @@ class TestBaseController(unittest.TestCase):
             yaml.dump(self.get_ss_config(), yml_file)
         return base_controller.load_config(temp_file_name)
 
-    @staticmethod
-    def test_load_config():
+    def test_load_config(self):
+        tmpfile = tempfile.NamedTemporaryFile(mode="wb", prefix="xrdsst-", suffix='.yaml', delete=False)
+        tmpfile.close()
+
+        temp_file_name = tmpfile.name
+        with open(temp_file_name, "w") as yml_file:
+            yaml.dump(TestBaseController._ss_config, yml_file)
         base_controller = BaseController()
-        temp_file_name = "base.yaml"
-        config_file = open(temp_file_name, "w")
-        config_file.close()
         with open(temp_file_name, "r") as yml_file:
             cfg = yaml.load(yml_file, Loader=yaml.FullLoader)
-        response = base_controller.load_config(temp_file_name)
-        os.remove(temp_file_name)
-        assert response == cfg
 
-    def test_load_config_exception(self):
+        assert cfg is not None
+
+        ctr_config = base_controller.load_config(temp_file_name)
+        os.remove(temp_file_name)
+
+        assert ctr_config == cfg
+
+    def test_load_config_access_exception(self):
         base_controller = BaseController()
+        base_controller.app = Mock()
         config_file = "/etc/shadow"
-        self.assertRaises(PermissionError, lambda: base_controller.load_config(config_file))
+        base_controller.load_config(config_file)
+
+        out, err = self.capsys.readouterr()
+        assert out.count("ermission") > 0
+        assert out.count("ould not read file") > 0
+
+        with self.capsys.disabled():
+            sys.stdout.write(out)
+            sys.stderr.write(err)
+
+    def test_load_config_malformed_yaml(self):
+        # Setup
+        tmpfile = tempfile.NamedTemporaryFile(mode="wb", prefix="xrdsst-", suffix='.yaml', delete=False)
+        tmpfile.write(bytes("{a", "utf-8"))
+        tmpfile.close()
+
+        # Given
+        config_file = tmpfile.name
+        base_controller = BaseController()
+        base_controller.app = Mock()
+        base_controller.app.close = Mock(return_value=None)
+
+        # When
+        base_controller.load_config(config_file)
+
+        # Cleanup
+        os.remove(config_file)
+
+        # Then
+        out, err = self.capsys.readouterr()
+        assert out.count("Error parsing config") > 0
+        assert out.count("line 1") > 0
+
+        with self.capsys.disabled():
+            sys.stdout.write(out)
+            sys.stderr.write(err)
+
+        base_controller.app.close.assert_called_once_with(os.EX_CONFIG)
+
+    def test_load_config_spelunked_keys(self):
+        # Setup
+        tmpfile = tempfile.NamedTemporaryFile(mode="w", prefix="xrdsst-", suffix='.yaml', delete=False)
+        tmpfile.writelines([
+            'kogging:\n',
+            '  file: asdqwe\n',
+            'security_server:\n',
+            '  name: xnnn\n',
+            '  ull: http://somesite.com'
+        ])
+        tmpfile.close()
+
+        # Given
+        config_file = tmpfile.name
+        base_controller = BaseController()
+        base_controller.app = Mock()
+        base_controller.app.close = Mock(return_value=None)
+
+        # When
+        base_controller.load_config(config_file)
+
+        # Cleanup
+        os.remove(config_file)
+
+        # Then
+        out, err = self.capsys.readouterr()
+        assert err.count("kogging NOT AMONG") > 0
+        assert err.count("ull NOT AMONG") > 0
+        assert out.count("Invalid configuration keys encountered") > 0
+
+        with self.capsys.disabled():
+            sys.stdout.write(out)
+            sys.stderr.write(err)
+
+        base_controller.app.close.assert_called_once_with(os.EX_CONFIG)
+
+    def test_load_config_serverless(self):
+        # Setup
+        config_data = [
+            'logging:\n',
+            '  file: logfile-test.log\n',
+            'security_server:\n'
+        ]
+
+        tmpfile = tempfile.NamedTemporaryFile(mode="w", prefix="xrdsst-", suffix='.yaml', delete=False)
+        tmpfile.writelines(config_data)
+        tmpfile.close()
+
+        # Given
+        config_file = tmpfile.name
+        base_controller = BaseController()
+        base_controller.app = Mock()
+        base_controller.app.close = Mock(return_value=None)
+        base_controller.is_output_tabulated = Mock(return_value=True)
+
+        # When
+        base_controller.load_config(config_file)
+
+        # Cleanup
+        os.remove(config_file)
+
+        # Then
+        out, err = self.capsys.readouterr()
+        assert err.count("No security servers defined") > 0
+
+        with self.capsys.disabled():
+            sys.stdout.write(out)
+            sys.stderr.write(err)
+
+        base_controller.app.close.assert_called_once_with(os.EX_CONFIG)
+
+    def test_load_config_servers_without_name_or_url(self):
+        # Setup
+        config_data = [
+            'logging:\n',
+            '  file: logfile-test.log\n',
+            'security_server:\n',
+            '  - name: first\n',
+            '    url: first_url\n',
+            '  - name: second\n',
+            '  - url: third_url\n',
+            '  - name: fourth\n',
+            '    url: fourth_url\n',
+            '    security_server_code: ASD\n'
+        ]
+
+        tmpfile = tempfile.NamedTemporaryFile(mode="w", prefix="xrdsst-", suffix='.yaml', delete=False)
+        tmpfile.writelines(config_data)
+        tmpfile.close()
+
+        # Given
+        config_file = tmpfile.name
+        base_controller = BaseController()
+        base_controller.app = Mock()
+        base_controller.app.close = Mock(return_value=None)
+        base_controller.is_output_tabulated = Mock(return_value=True)
+
+        # When
+        base_controller.load_config(config_file)
+
+        # Cleanup
+        os.remove(config_file)
+
+        # Then
+        out, err = self.capsys.readouterr()
+        assert err.count("security_server[2] missing required 'url'") == 1
+        assert err.count("security_server[3] missing required 'name'") == 1
+
+        with self.capsys.disabled():
+            sys.stdout.write(out)
+            sys.stderr.write(err)
+
+        base_controller.app.close.assert_called_once_with(os.EX_CONFIG)
+
+    def test_load_config_servers_name_or_url_non_unique(self):
+        # Setup
+        config_data = [
+            'logging:\n',
+            '  file: logfile-test.log\n',
+            'security_server:\n',
+            '  - name: first\n',
+            '    url: first_url\n',
+            '  - name: second\n',
+            '    url: second_url\n',
+            '  - url: third_url\n',
+            '    name: third\n',
+            '  - name: fourth\n',
+            '    url: third_url\n',
+            '    security_server_code: QED\n',
+            '  - name: fifth\n',
+            '    url: second_url\n',
+            '  - name: first\n',
+            '    url: faraway.com\n'
+        ]
+
+        tmpfile = tempfile.NamedTemporaryFile(mode="w", prefix="xrdsst-", suffix='.yaml', delete=False)
+        tmpfile.writelines(config_data)
+        tmpfile.close()
+
+        # Given
+        config_file = tmpfile.name
+        base_controller = BaseController()
+        base_controller.app = Mock()
+        base_controller.app.close = Mock(return_value=None)
+        base_controller.is_output_tabulated = Mock(return_value=True)
+
+        # When
+        base_controller.load_config(config_file)
+
+        # Cleanup
+        os.remove(config_file)
+
+        # Then
+        out, err = self.capsys.readouterr()
+        assert err.count("security_server[1] 'name' value 'first' is non-unique") == 1
+        assert err.count("security_server[6] 'name' value 'first' is non-unique") == 1
+        assert err.count("security_server[2] 'url' value 'second_url' is non-unique") == 1
+        assert err.count("security_server[5] 'url' value 'second_url' is non-unique") == 1
+        assert err.count("security_server[3] 'url' value 'third_url' is non-unique") == 1
+        assert err.count("security_server[4] 'url' value 'third_url' is non-unique") == 1
+
+        with self.capsys.disabled():
+            sys.stdout.write(out)
+            sys.stderr.write(err)
+
+        base_controller.app.close.assert_called_once_with(os.EX_CONFIG)
 
     def test_init_logging(self):
         temp_file_name = "temp.log"
@@ -74,7 +294,6 @@ class TestBaseController(unittest.TestCase):
 
         logging.shutdown()
         os.remove(temp_file_name)
-
 
     def test_init_logging_no_write_access(self):
         temp_file_name = "/root/nocanwrite.log"
@@ -101,57 +320,65 @@ class TestBaseController(unittest.TestCase):
         assert len(logging.getLogger().handlers) == 1
 
     def test_get_api_key(self):
-        with patch.object(BaseController, 'create_api_key', return_value='api-key-123'):
+        with XRDSSTTest() as app:
+            with patch.object(BaseController, 'create_api_key', return_value='88888888-8000-4000-a000-727272727272'):
+                base_controller = BaseController()
+                base_controller.app = app
+                temp_file_name = os.path.join(ROOT_DIR, "conf.yaml")
+                config = self.create_temp_conf(base_controller, temp_file_name)
+                security_server = config["security_server"][0]
+                security_server["api_key"] = 'X-Road-apikey token=some key'
+                key = base_controller.get_api_key(config, security_server)
+                assert key != 'X-Road-apikey token=api-key-123'
+                security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'
+                key = base_controller.get_api_key(config, security_server)
+                os.remove(temp_file_name)
+                assert key == 'X-Road-apikey token=88888888-8000-4000-a000-727272727272'
+
+    def test_get_api_key_ssh_key_exception(self):
+        with XRDSSTTest() as app:
             base_controller = BaseController()
+            base_controller.app = app
             temp_file_name = os.path.join(ROOT_DIR, "conf.yaml")
             config = self.create_temp_conf(base_controller, temp_file_name)
             security_server = config["security_server"][0]
-            security_server["api_key"] = 'X-Road-apikey token=some key'
-            key = base_controller.get_api_key(config, security_server)
-            assert key != 'X-Road-apikey token=api-key-123'
             security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'
-            key = base_controller.get_api_key(config, security_server)
+            base_controller.get_api_key(config, security_server)
             os.remove(temp_file_name)
-            assert key == 'X-Road-apikey token=api-key-123'
-
-    def test_get_api_key_ssh_key_exception(self):
-        base_controller = BaseController()
-        temp_file_name = os.path.join(ROOT_DIR, "conf.yaml")
-        config = self.create_temp_conf(base_controller, temp_file_name)
-        security_server = config["security_server"][0]
-        security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'
-        base_controller.get_api_key(config, security_server)
-        os.remove(temp_file_name)
-        self.assertRaises(Exception)
+            self.assertRaises(Exception)
 
     def test_get_api_key_json_exception(self):
-        base_controller = BaseController()
-        temp_file_name = os.path.join(ROOT_DIR, "conf.yaml")
-        config = self.create_temp_conf(base_controller, temp_file_name)
-        temp_key_file = open("my_key", "w")
-        temp_key_file.close()
-        config["api_key"][0]["key"] = "my_key"
-        security_server = config["security_server"][0]
-        security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'
-        base_controller.get_api_key(config, security_server)
-        os.remove(temp_file_name)
-        os.remove("my_key")
-        self.assertRaises(Exception)
+        with XRDSSTTest() as app:
+            base_controller = BaseController()
+            base_controller.app = app
+            temp_file_name = os.path.join(ROOT_DIR, "conf.yaml")
+            config = self.create_temp_conf(base_controller, temp_file_name)
+            temp_key_file = open("my_key", "w")
+            temp_key_file.close()
+            config["api_key"][0]["key"] = "my_key"
+            security_server = config["security_server"][0]
+            security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'
+            base_controller.get_api_key(config, security_server)
+            os.remove(temp_file_name)
+            os.remove("my_key")
+            self.assertRaises(Exception)
 
     def test_initialize_basic_conf_values(self):
-        base_controller = BaseController()
-        temp_file_name = os.path.join(ROOT_DIR, "conf.yaml")
-        config = self.create_temp_conf(base_controller, temp_file_name)
-        security_server = config["security_server"][0]
-        configuration = Configuration()
-        configuration.api_key['Authorization'] = security_server["api_key"]
-        configuration.host = security_server["url"]
-        configuration.verify_ssl = False
-        response = base_controller.initialize_basic_config_values(security_server)
-        os.remove(temp_file_name)
-        assert response.api_key == configuration.api_key
-        assert response.host == configuration.host
-        assert response.verify_ssl == configuration.verify_ssl
+        with XRDSSTTest() as app:
+            base_controller = BaseController()
+            base_controller.app = app
+            temp_file_name = os.path.join(ROOT_DIR, "conf.yaml")
+            config = self.create_temp_conf(base_controller, temp_file_name)
+            security_server = config["security_server"][0]
+            configuration = Configuration()
+            configuration.api_key['Authorization'] = security_server["api_key"]
+            configuration.host = security_server["url"]
+            configuration.verify_ssl = False
+            response = base_controller.initialize_basic_config_values(security_server)
+            os.remove(temp_file_name)
+            assert response.api_key == configuration.api_key
+            assert response.host == configuration.host
+            assert response.verify_ssl == configuration.verify_ssl
 
     def test_configfile_argument_added(self):
         base_controller = BaseController()
@@ -171,13 +398,13 @@ class TestBaseController(unittest.TestCase):
         base_controller.app.close.assert_called_once_with(os.EX_CONFIG)
 
     def test_conversion_of_text_to_swagger_enum_succeeds(self):
-        assert 'HTTP' == BaseController.convert_swagger_enum(ConnectionType, "HTTP")
-        assert 'HTTPS' == BaseController.convert_swagger_enum(ConnectionType, "HTTPS")
-        assert 'HTTPS_NO_AUTH' == BaseController.convert_swagger_enum(ConnectionType, "HTTPS_NO_AUTH")
+        assert 'HTTP' == convert_swagger_enum(ConnectionType, "HTTP")
+        assert 'HTTPS' == convert_swagger_enum(ConnectionType, "HTTPS")
+        assert 'HTTPS_NO_AUTH' == convert_swagger_enum(ConnectionType, "HTTPS_NO_AUTH")
 
     def test_conversion_of_text_to_swagger_enum_fails(self):
         try:
-            BaseController.convert_swagger_enum(ConnectionType, "HTTPX")
+            convert_swagger_enum(ConnectionType, "HTTPX")
             raise AssertionError("Conversion of 'HTTPX' to ConnectionType should have failed.")
         except SyntaxWarning:
             pass

--- a/tests/unit/test_cert.py
+++ b/tests/unit/test_cert.py
@@ -332,6 +332,7 @@ class TestCert(unittest.TestCase):
                 sys.stdout.write(out)
                 sys.stderr.write(err)
 
+    @mock.patch('xrdsst.core.api_util.is_ss_connectable', lambda x: (False, 'connection error (test injected)'))
     def test_cert_import_nonresolving_url(self):
         with XRDSSTTest() as app:
             cert_controller = CertController()
@@ -392,6 +393,7 @@ class TestCert(unittest.TestCase):
                         sys.stdout.write(out)
                         sys.stderr.write(err)
 
+    @mock.patch('xrdsst.core.api_util.is_ss_connectable', lambda x: (False, 'connection error (test injected)'))
     def test_cert_register_nonresolving_url(self):
         with XRDSSTTest() as app:
             cert_controller = CertController()

--- a/tests/unit/test_cert.py
+++ b/tests/unit/test_cert.py
@@ -6,10 +6,10 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
-import urllib3
 from dateutil.tz import tzutc
 
 from definitions import ROOT_DIR
+from tests.util.test_util import TokenTestData, StatusTestData
 from xrdsst.controllers.cert import CertController
 from xrdsst.models import Token, TokenStatus, TokenType, KeyUsageType, Key, TokenCertificate, CertificateOcspStatus, \
     CertificateStatus, CertificateDetails, KeyUsage, PossibleAction, TokenCertificateSigningRequest
@@ -127,21 +127,6 @@ class CertTestData:
         usage=KeyUsageType.AUTHENTICATION,
         certificate_signing_requests=[],
         certificates=[]
-    )
-
-    keyless_token_response = Token(
-        available=True,
-        id=0,
-        logged_in=True,
-        name='softToken-0',
-        possible_actions=None,
-        read_only=False,
-        saved_to_configuration=True,
-        serial_number=None,
-        status=TokenStatus.OK,
-        token_infos=[{'key': 'Type'}, {'value': 'Software'}],
-        type=TokenType.SOFTWARE,
-        keys=[]
     )
 
     token_with_two_csrs_response = Token(
@@ -268,7 +253,7 @@ class TestCert(unittest.TestCase):
                   '/some/where/authcert',
                   '/some/where/signcert',
               ],
-              'api_key': 'X-Road-apikey token=api-key',
+              'api_key': 'X-Road-apikey token=88888888-8000-4000-a000-727272727272',
               'owner_dn_country': 'FI',
               'owner_dn_org': 'UNSERE',
               'owner_member_class': 'VOG',
@@ -314,6 +299,7 @@ class TestCert(unittest.TestCase):
                     cert_controller = CertController()
                     cert_controller.app = app
                     cert_controller.load_config = (lambda: self.ss_config)
+                    cert_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                     reported_downloads = cert_controller.download_csrs()
 
                     assert len(reported_downloads) == 2
@@ -332,21 +318,29 @@ class TestCert(unittest.TestCase):
                     assert os.path.exists(sign_csr_file)
 
     def test_cert_import_nonexisting_certs(self):
-        cert_controller = CertController()
-        cert_controller.load_config = (lambda: self.ss_config)
-        cert_controller.import_()
+        with XRDSSTTest() as app:
+            cert_controller = CertController()
+            cert_controller.app = app
+            cert_controller.load_config = (lambda: self.ss_config)
+            cert_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
+            cert_controller.import_()
 
-        out, err = self.capsys.readouterr()
-        assert out.count("does not exist") > 0
+            out, err = self.capsys.readouterr()
+            assert out.count("references non-existent file") > 0
 
-        with self.capsys.disabled():
-            sys.stdout.write(out)
-            sys.stderr.write(err)
+            with self.capsys.disabled():
+                sys.stdout.write(out)
+                sys.stderr.write(err)
 
     def test_cert_import_nonresolving_url(self):
-        cert_controller = CertController()
-        cert_controller.load_config = (lambda: self.ss_config_with_authcert())
-        self.assertRaises(urllib3.exceptions.MaxRetryError, lambda: cert_controller.import_())
+        with XRDSSTTest() as app:
+            cert_controller = CertController()
+            cert_controller.app = app
+            cert_controller.load_config = (lambda: self.ss_config_with_authcert())
+            cert_controller.import_()
+
+            out, err = self.capsys.readouterr()
+            assert out.count("SKIPPED 'ssX': no connectivity") > 0
 
     def test_cert_import_already_existing(self):
         class AlreadyExistingResponse:
@@ -363,6 +357,7 @@ class TestCert(unittest.TestCase):
                     cert_controller = CertController()
                     cert_controller.app = app
                     cert_controller.load_config = (lambda: self.ss_config_with_authcert())
+                    cert_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                     cert_controller.import_()
 
                     out, err = self.capsys.readouterr()
@@ -387,27 +382,34 @@ class TestCert(unittest.TestCase):
                     cert_controller = CertController()
                     cert_controller.app = app
                     cert_controller.load_config = (lambda: self.ss_config_with_authcert())
+                    cert_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                     cert_controller.import_()
 
                     out, err = self.capsys.readouterr()
-                    assert out.count("permission") > 0
+                    assert err.count("permission") > 0
 
                     with self.capsys.disabled():
                         sys.stdout.write(out)
                         sys.stderr.write(err)
 
     def test_cert_register_nonresolving_url(self):
-        cert_controller = CertController()
-        cert_controller.load_config = (lambda: self.ss_config)
-        self.assertRaises(urllib3.exceptions.MaxRetryError, lambda: cert_controller.register())
+        with XRDSSTTest() as app:
+            cert_controller = CertController()
+            cert_controller.app = app
+            cert_controller.load_config = (lambda: self.ss_config)
+            cert_controller.register()
+
+            out, err = self.capsys.readouterr()
+            assert out.count("SKIPPED 'ssX': no connectivity") > 0
 
     def test_cert_register_no_auth_key(self):
         with XRDSSTTest() as app:
             with mock.patch('xrdsst.api.tokens_api.TokensApi.get_token',
-                            return_value=CertTestData.keyless_token_response):
+                            return_value=TokenTestData.token_keyless):
                 cert_controller = CertController()
                 cert_controller.app = app
                 cert_controller.load_config = (lambda: self.ss_config_with_authcert())
+                cert_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                 cert_controller.register()
 
                 out, err = self.capsys.readouterr()
@@ -424,6 +426,7 @@ class TestCert(unittest.TestCase):
                 cert_controller = CertController()
                 cert_controller.app = app
                 cert_controller.load_config = (lambda: self.ss_config_with_authcert())
+                cert_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                 cert_controller.register()
 
                 out, err = self.capsys.readouterr()
@@ -440,6 +443,7 @@ class TestCert(unittest.TestCase):
                 cert_controller = CertController()
                 cert_controller.app = app
                 cert_controller.load_config = (lambda: self.ss_config_with_authcert())
+                cert_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                 cert_controller.register()
 
                 out, err = self.capsys.readouterr()
@@ -456,6 +460,7 @@ class TestCert(unittest.TestCase):
                 cert_controller = CertController()
                 cert_controller.app = app
                 cert_controller.load_config = (lambda: self.ss_config_with_authcert())
+                cert_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                 cert_controller.register()
 
                 out, err = self.capsys.readouterr()
@@ -476,6 +481,7 @@ class TestCert(unittest.TestCase):
                         cert_controller = CertController()
                         cert_controller.app = app
                         cert_controller.load_config = (lambda: self.ss_config_with_authcert())
+                        cert_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                         cert_controller.activate()
 
                         out, err = self.capsys.readouterr()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from tests.util.test_util import StatusTestData
 from xrdsst.controllers.client import ClientController
 from xrdsst.models import Client, ConnectionType, ClientStatus
 from xrdsst.main import XRDSSTTest
@@ -67,6 +68,7 @@ class TestClient(unittest.TestCase):
                 client_controller = ClientController()
                 client_controller.app = app
                 client_controller.load_config = (lambda: self.ss_config)
+                client_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                 client_controller.add()
 
                 out, err = self.capsys.readouterr()
@@ -90,6 +92,7 @@ class TestClient(unittest.TestCase):
                 client_controller = ClientController()
                 client_controller.app = app
                 client_controller.load_config = (lambda: self.ss_config)
+                client_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                 client_controller.add()
 
                 out, err = self.capsys.readouterr()
@@ -105,6 +108,7 @@ class TestClient(unittest.TestCase):
                 client_controller = ClientController()
                 client_controller.app = app
                 client_controller.load_config = (lambda: self.ss_config)
+                client_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                 client_controller.register()
 
                 out, err = self.capsys.readouterr()
@@ -131,6 +135,7 @@ class TestClient(unittest.TestCase):
                     client_controller = ClientController()
                     client_controller.app = app
                     client_controller.load_config = (lambda: self.ss_config)
+                    client_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                     client_controller.register()
 
                     out, err = self.capsys.readouterr()
@@ -157,6 +162,7 @@ class TestClient(unittest.TestCase):
                     client_controller = ClientController()
                     client_controller.app = app
                     client_controller.load_config = (lambda: self.ss_config)
+                    client_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                     client_controller.register()
 
                     out, err = self.capsys.readouterr()

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,35 +1,65 @@
+import copy
+import os
+import sys
 import unittest
+from pathlib import Path
 from unittest import mock
+
+import pytest
+
+from definitions import ROOT_DIR
 from xrdsst.configuration.configuration import Configuration
 from xrdsst.controllers.init import InitServerController
+from xrdsst.core.conf_keys import ConfKeysRoot, ConfKeysSecurityServer
+from xrdsst.main import XRDSSTTest
 from xrdsst.models import TokenInitStatus
 from xrdsst.models.initialization_status import InitializationStatus
 from xrdsst.rest.rest import ApiException
-from tests.unit.test_base_controller import TestBaseController
 
+
+def init_api_config():
+    config = Configuration()
+    config.api_key['Authorization'] = 'X-Road-apikey token=api-key'
+    config.host = 'https://ss:4000/api/v1'
+    config.verify_ssl = False
+    return config
+
+
+UNINITIALIZED_STATUS = InitializationStatus(is_anchor_imported=False, is_server_code_initialized=False,
+                                            is_server_owner_initialized=False,
+                                            software_token_init_status=TokenInitStatus.NOT_INITIALIZED)
 
 class TestInit(unittest.TestCase):
+    configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
+    _ss_config = {
+        'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
+         'api_key': [{'url': 'https://localhost:4000/api/v1/api-keys',
+                      'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
+        'security_server':
+            [{'name': 'ss',
+              'url': 'https://no.there.com:4000/api/v1',
+              'api_key': 'X-Road-apikey token=api-key',
+              'configuration_anchor': configuration_anchor,
+              'owner_member_class': 'GOV',
+              'owner_member_code': '1234',
+              'security_server_code': 'SS',
+              'software_token_pin': '1234',
+              }]}
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        base_controller = TestBaseController()
-        self._ss_config = base_controller.get_ss_config()
-        config = Configuration()
-        config.api_key['Authorization'] = self._ss_config["security_server"][0]["api_key"]
-        config.host = self._ss_config["security_server"][0]["url"]
-        config.verify_ssl = False
-        self._config = config
+    @pytest.fixture(autouse=True)
+    def capsys(self, capsys):
+        self.capsys = capsys
 
     def test_check_init_status(self):
         initialization_status = InitializationStatus(is_anchor_imported=True,
                                                      is_server_code_initialized=True,
                                                      is_server_owner_initialized=True,
-                                                     software_token_init_status='NOT_INITLIALIZED')
+                                                     software_token_init_status=TokenInitStatus.NOT_INITIALIZED)
         with mock.patch('xrdsst.controllers.init.InitializationApi.get_initialization_status',
                         return_value=initialization_status):
             init = InitServerController()
             init.load_config = (lambda: self._ss_config)
-            response = init.check_init_status(self._config)
+            response = init.check_init_status(init_api_config())
             assert response == initialization_status
 
     def test_check_init_status_exception(self):
@@ -37,7 +67,7 @@ class TestInit(unittest.TestCase):
                         side_effect=ApiException):
             init = InitServerController()
             init.load_config = (lambda: self._ss_config)
-            init.check_init_status(self._config)
+            init.check_init_status(init_api_config())
             self.assertRaises(ApiException)
 
     def test_upload_anchor(self):
@@ -46,7 +76,7 @@ class TestInit(unittest.TestCase):
                         return_value=expected_response):
             init = InitServerController()
             init.load_config = (lambda: self._ss_config)
-            response = init.upload_anchor(self._config, self._ss_config["security_server"][0])
+            response = init.upload_anchor(init_api_config(), self._ss_config["security_server"][0])
             assert response == expected_response
 
     def test_upload_anchor_exception(self):
@@ -54,7 +84,7 @@ class TestInit(unittest.TestCase):
                         side_effect=ApiException):
             init = InitServerController()
             init.load_config = (lambda: self._ss_config)
-            init.upload_anchor(self._config, self._ss_config["security_server"][0])
+            init.upload_anchor(init_api_config(), self._ss_config["security_server"][0])
             self.assertRaises(ApiException)
 
     def test_init_security_server(self):
@@ -63,7 +93,7 @@ class TestInit(unittest.TestCase):
                         return_value=expected_response):
             init = InitServerController()
             init.load_config = (lambda: self._ss_config)
-            response = init.init_security_server(self._config,
+            response = init.init_security_server(init_api_config(),
                                                  self._ss_config["security_server"][0])
             assert response == expected_response
 
@@ -72,31 +102,69 @@ class TestInit(unittest.TestCase):
                         side_effect=ApiException):
             init = InitServerController()
             init.load_config = (lambda: self._ss_config)
-            init.init_security_server(self._config, self._ss_config["security_server"][0])
+            init.init_security_server(init_api_config(), self._ss_config["security_server"][0])
             self.assertRaises(ApiException)
 
     def test_initialize_server_when_already_initialized(self):
-        initialization_status = InitializationStatus(is_anchor_imported=True,
-                                                     is_server_code_initialized=True,
-                                                     is_server_owner_initialized=True,
-                                                     software_token_init_status=TokenInitStatus.INITIALIZED)
-        with mock.patch('xrdsst.controllers.init.InitializationApi.get_initialization_status',
-                        return_value=initialization_status):
-            init = InitServerController()
-            init.load_config = (lambda: self._ss_config)
-            self.assertEqual(init.initialize_server(self._ss_config), None)
+        with XRDSSTTest() as app:
+            initialization_status = InitializationStatus(is_anchor_imported=True,
+                                                         is_server_code_initialized=True,
+                                                         is_server_owner_initialized=True,
+                                                         software_token_init_status=TokenInitStatus.INITIALIZED)
+            with mock.patch('xrdsst.controllers.init.InitializationApi.get_initialization_status',
+                            return_value=initialization_status):
+                init = InitServerController()
+                init.app = app
+                init.load_config = (lambda: self._ss_config)
+                self.assertEqual(init.initialize_server(self._ss_config), None)
 
     def test_initialize_server_when_not_initialized(self):
-        initialization_status = InitializationStatus(is_anchor_imported=False,
-                                                     is_server_code_initialized=False,
-                                                     is_server_owner_initialized=False,
-                                                     software_token_init_status=TokenInitStatus.NOT_INITIALIZED)
-        with mock.patch('xrdsst.controllers.init.InitializationApi.get_initialization_status',
-                        return_value=initialization_status):
-            with mock.patch('xrdsst.controllers.init.SystemApi.upload_initial_anchor',
-                            return_value=200):
-                with mock.patch('xrdsst.controllers.init.InitializationApi.init_security_server',
+        with XRDSSTTest() as app:
+            initialization_status = UNINITIALIZED_STATUS
+            with mock.patch('xrdsst.controllers.init.InitializationApi.get_initialization_status',
+                            return_value=initialization_status):
+                with mock.patch('xrdsst.controllers.init.SystemApi.upload_initial_anchor',
                                 return_value=200):
-                    init = InitServerController()
-                    init.load_config = (lambda: self._ss_config)
-                    self.assertEqual(init.initialize_server(self._ss_config), None)
+                    with mock.patch('xrdsst.controllers.init.InitializationApi.init_security_server',
+                                    return_value=200):
+                        init = InitServerController()
+                        init.app = app
+                        init.load_config = (lambda: self._ss_config)
+                        self.assertEqual(init.initialize_server(self._ss_config), None)
+
+    def test_init_token_id_unconfigured(self):
+        with XRDSSTTest() as app:
+            initialization_status = UNINITIALIZED_STATUS
+            with mock.patch('xrdsst.controllers.init.InitializationApi.get_initialization_status',
+                            return_value=initialization_status):
+                with mock.patch('xrdsst.controllers.init.SystemApi.upload_initial_anchor',
+                                return_value=200):
+                    with mock.patch('xrdsst.controllers.init.InitializationApi.init_security_server',
+                                    return_value=200):
+                        init_controller = InitServerController()
+                        init_controller.app = app
+                        init_controller.load_config = (lambda: self._ss_config)
+                        init_controller._default()
+
+                        out, err = self.capsys.readouterr()
+                        assert out.count("SKIPPED 'ss'") == 1
+                        assert out.count("'ss' [init]: 'software_token_id' missing") == 1
+
+    def test_init_attempt_of_unreachable_server(self):  # no preconditions ordinarily, but must not be done if no connectivity
+        with XRDSSTTest() as app:
+            initialization_status = UNINITIALIZED_STATUS
+            with mock.patch('xrdsst.controllers.init.InitializationApi.get_initialization_status',
+                            return_value=initialization_status):
+                with mock.patch('xrdsst.controllers.init.SystemApi.upload_initial_anchor',
+                                return_value=200):
+                    with mock.patch('xrdsst.controllers.init.InitializationApi.init_security_server',
+                                    return_value=200):
+                        init_controller = InitServerController()
+                        init_controller.app = app
+                        init_config = copy.deepcopy(self._ss_config)
+                        init_config[ConfKeysRoot.CONF_KEY_ROOT_SERVER][0][ConfKeysSecurityServer.CONF_KEY_SOFT_TOKEN_ID] = 0
+                        init_controller.load_config = (lambda: init_config)
+                        init_controller._default()
+
+                        out, err = self.capsys.readouterr()
+                        assert out.count("SKIPPED 'ss': no connectivity") > 0

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -4,7 +4,9 @@ from unittest import mock
 
 import pytest
 
+from tests.util.test_util import StatusTestData
 from xrdsst.controllers.service import ServiceController
+from xrdsst.controllers.status import StatusController
 from xrdsst.models import Client, ConnectionType, ClientStatus, ServiceDescription, ServiceType
 from xrdsst.main import XRDSSTTest
 from xrdsst.rest.rest import ApiException
@@ -76,6 +78,7 @@ class TestService(unittest.TestCase):
                     service_controller = ServiceController()
                     service_controller.app = app
                     service_controller.load_config = (lambda: self.ss_config)
+                    service_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                     service_controller.add_description()
 
                     out, err = self.capsys.readouterr()
@@ -99,10 +102,11 @@ class TestService(unittest.TestCase):
                 service_controller = ServiceController()
                 service_controller.app = app
                 service_controller.load_config = (lambda: self.ss_config)
+                service_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                 service_controller.add_description()
 
                 out, err = self.capsys.readouterr()
-                assert out.count("ClientsApi->find_clients") > 0
+                assert err.count("ClientsApi->find_clients") > 0
 
                 with self.capsys.disabled():
                     sys.stdout.write(out)
@@ -133,6 +137,7 @@ class TestService(unittest.TestCase):
                     service_controller = ServiceController()
                     service_controller.app = app
                     service_controller.load_config = (lambda: self.ss_config)
+                    service_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                     service_controller.add_description()
 
                     out, err = self.capsys.readouterr()
@@ -167,10 +172,11 @@ class TestService(unittest.TestCase):
                     service_controller = ServiceController()
                     service_controller.app = app
                     service_controller.load_config = (lambda: self.ss_config)
+                    service_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                     service_controller.add_description()
 
                     out, err = self.capsys.readouterr()
-                    assert out.count("ClientsApi->add_client_service_description") > 0
+                    assert err.count("ClientsApi->add_client_service_description") > 0
 
                     with self.capsys.disabled():
                         sys.stdout.write(out)
@@ -196,6 +202,7 @@ class TestService(unittest.TestCase):
                         service_controller = ServiceController()
                         service_controller.app = app
                         service_controller.load_config = (lambda: self.ss_config)
+                        service_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                         service_controller.enable_description()
 
                         out, err = self.capsys.readouterr()
@@ -232,6 +239,7 @@ class TestService(unittest.TestCase):
                         service_controller = ServiceController()
                         service_controller.app = app
                         service_controller.load_config = (lambda: self.ss_config)
+                        service_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
                         service_controller.enable_description()
 
                         out, err = self.capsys.readouterr()

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -31,7 +31,7 @@ class TestStatus(unittest.TestCase):
                      'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
         'security_server':
             [{'name': 'longServerName',
-              'url': 'https://google.com:443',
+              'url': 'https://unrealz5BAlxpy9yo0XpplIQbPC.com:443',
               'certificates': [
                   '/some/where/authcert',
                   '/some/where/signcert',
@@ -70,6 +70,7 @@ class TestStatus(unittest.TestCase):
                 sys.stdout.write(out)
                 sys.stderr.write(err)
 
+    @mock.patch('xrdsst.core.api_util.is_ss_connectable', lambda x: (True, 'good connectivity (test injected)'))
     @mock.patch.object(UserApi, 'get_user', side_effect=ApiException(http_resp=ObjectStruct(status=401, reason=None, data='{"status":401}', getheaders=(lambda: None))))
     def test_status_api_key_not_accepted(self, userapi_mock):
         with XRDSSTTest() as app:
@@ -86,6 +87,7 @@ class TestStatus(unittest.TestCase):
                 sys.stdout.write(out)
                 sys.stderr.write(err)
 
+    @mock.patch('xrdsst.core.api_util.is_ss_connectable', lambda x: (True, 'good connectivity (test injected)'))
     @mock.patch.object(UserApi, 'get_user', sysadm_secoff)
     @mock.patch.object(SystemApi, 'system_version', (lambda x: Version(info="6.25.0")))
     @mock.patch.object(DiagnosticsApi, 'get_global_conf_diagnostics', (lambda x:
@@ -98,8 +100,6 @@ class TestStatus(unittest.TestCase):
             status_controller.app = app
             status_controller.load_config = (lambda: self.ss_config)
             status_controller._default()
-
-            out, err = self.capsys.readouterr()
 
             # Global status
             assert status_controller.app._last_rendered[0][1][0].count('FAIL') == 1
@@ -122,10 +122,7 @@ class TestStatus(unittest.TestCase):
             for col in range(4, 9):
                 assert '' == status_controller.app._last_rendered[0][1][col].strip()
 
-            with self.capsys.disabled():
-                sys.stdout.write(out)
-                sys.stderr.write(err)
-
+    @mock.patch('xrdsst.core.api_util.is_ss_connectable', lambda x: (True, 'good connectivity (test injected)'))
     @mock.patch.object(UserApi, 'get_user', sysadm_secoff)
     @mock.patch.object(SystemApi, 'system_version', (lambda x: Version(info="6.25.0")))
     @mock.patch.object(DiagnosticsApi, 'get_global_conf_diagnostics', (lambda x: DiagnosticsTestData.global_ok_success))

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -8,7 +8,7 @@ import pytest
 
 from datetime import datetime, timedelta
 from definitions import ROOT_DIR
-from tests.util.test_util import ObjectStruct
+from tests.util.test_util import ObjectStruct, DiagnosticsTestData, InitTestData
 from xrdsst.api import UserApi, SystemApi, DiagnosticsApi, InitializationApi, SecurityServersApi, TokensApi
 from xrdsst.controllers.status import StatusController
 from xrdsst.main import XRDSSTTest
@@ -31,12 +31,12 @@ class TestStatus(unittest.TestCase):
                      'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
         'security_server':
             [{'name': 'longServerName',
-              'url': 'https://non.existing.url.blah:8999/api/v1',
+              'url': 'https://google.com:443',
               'certificates': [
                   '/some/where/authcert',
                   '/some/where/signcert',
               ],
-              'api_key': 'X-Road-apikey token=api-key',
+              'api_key': 'X-Road-apikey token=86668888-8000-4000-a000-277727227272',
               'owner_dn_country': 'FI',
               'owner_dn_org': 'UNSERE',
               'owner_member_class': 'VOG',
@@ -128,12 +128,8 @@ class TestStatus(unittest.TestCase):
 
     @mock.patch.object(UserApi, 'get_user', sysadm_secoff)
     @mock.patch.object(SystemApi, 'system_version', (lambda x: Version(info="6.25.0")))
-    @mock.patch.object(DiagnosticsApi, 'get_global_conf_diagnostics', (lambda x:
-        GlobalConfDiagnostics(status_class="OK", status_code="SUCCESS", prev_update_at=datetime.now(), next_update_at=datetime.now() + timedelta(minutes=5))
-    ))
-    @mock.patch.object(InitializationApi, 'get_initialization_status', (lambda x:
-        InitializationStatus(is_anchor_imported=True, is_server_owner_initialized=True, is_server_code_initialized=True, software_token_init_status=TokenStatus.OK)
-    ))
+    @mock.patch.object(DiagnosticsApi, 'get_global_conf_diagnostics', (lambda x: DiagnosticsTestData.global_ok_success))
+    @mock.patch.object(InitializationApi, 'get_initialization_status', (lambda x: InitTestData.all_initialized))
     @mock.patch.object(SecurityServersApi, 'get_security_servers', (lambda x, **kwargs: [
         SecurityServer(id="TEST:GOV:8672:SSLONG", instance_id="TEST", member_class="GOV", server_address="4.2.2.1", server_code="SSLONG")
     ]))
@@ -173,7 +169,7 @@ class TestStatus(unittest.TestCase):
             assert status_controller.app._last_rendered[0][1][3].count('ANCHOR INITIALIZED') == 1
             assert status_controller.app._last_rendered[0][1][3].count('CODE INITIALIZED') == 1
             assert status_controller.app._last_rendered[0][1][3].count('OWNER INITIALIZED') == 1
-            assert status_controller.app._last_rendered[0][1][3].count('TOKEN OK') == 1
+            assert status_controller.app._last_rendered[0][1][3].count('TOKEN INITIALIZED') == 1
 
             # TSA list
             assert status_controller.app._last_rendered[0][1][4].count('one tsa') == 1

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -307,22 +307,7 @@ class TestToken(unittest.TestCase):
                     self.assertRaises(IndexError, lambda: token_controller.init_keys())
 
     def test_token_list_nonresolving_url(self):
+        urllib3.util.retry.Retry.DEFAULT = urllib3.util.retry.Retry(0)
         token_controller = TokenController()
         token_controller.load_config = (lambda: self.ss_config)
         self.assertRaises(urllib3.exceptions.MaxRetryError, lambda: token_controller.list())
-
-    def test_token_login_nonresolving_url(self):
-        with XRDSSTTest() as app:
-            token_controller = TokenController()
-            token_controller.app = app
-            token_controller.load_config = (lambda: self.ss_config)
-            token_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
-            self.assertRaises(urllib3.exceptions.MaxRetryError, lambda: token_controller.login())
-
-    def test_token_init_keys_nonresolving_url(self):
-        with XRDSSTTest() as app:
-            token_controller = TokenController()
-            token_controller.app = app
-            token_controller.load_config = (lambda: self.ss_config)
-            token_controller.get_server_status = (lambda x, y: StatusTestData.server_status_essentials_complete)
-            self.assertRaises(urllib3.exceptions.MaxRetryError, lambda: token_controller.init_keys())

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -1,12 +1,16 @@
+import copy
 import json
 import os
 import time
+from datetime import datetime, timedelta
 from urllib.parse import urlparse
 import requests
-from xrdsst.controllers.base import BaseController
 from xrdsst.controllers.status import ServerStatus
-from xrdsst.core.util import default_auth_key_label
-from xrdsst.models import ConnectionType, TokenInitStatus
+from xrdsst.core.api_util import StatusRoles, StatusVersion, StatusGlobal, StatusServerInitialization, \
+    StatusServerTimestamping, StatusToken, StatusKeys, StatusCsrs, StatusCerts
+from xrdsst.core.util import default_auth_key_label, convert_swagger_enum
+from xrdsst.models import ConnectionType, TokenInitStatus, User, InitializationStatus, GlobalConfDiagnostics, Token, \
+    TokenStatus, TokenType, PossibleAction
 
 
 class ObjectStruct:
@@ -15,6 +19,154 @@ class ObjectStruct:
     def __eq__(self, other): return self.__dict__ == other.__dict__
 
     def __ne__(self, other): return self.__dict__ != other.__dict__
+
+
+class UserTestData:
+    with_all_grants = User(
+        username='api-key-N',
+        roles=[
+            'ROLE_XROAD_REGISTRATION_OFFICER', 'ROLE_XROAD_SECURITYSERVER_OBSERVER', 'ROLE_XROAD_SECURITY_OFFICER',
+            'ROLE_XROAD_SERVICE_ADMINISTRATOR', 'ROLE_XROAD_SYSTEM_ADMINISTRATOR'
+        ],
+        permissions=[
+            'ACTIVATE_DEACTIVATE_TOKEN', 'ACTIVATE_DISABLE_AUTH_CERT', 'ACTIVATE_DISABLE_SIGN_CERT', 'ADD_CLIENT',
+            'ADD_CLIENT_INTERNAL_CERT', 'ADD_LOCAL_GROUP', 'ADD_OPENAPI3', 'ADD_OPENAPI3_ENDPOINT', 'ADD_TSP',
+            'ADD_WSDL', 'BACKUP_CONFIGURATION', 'CREATE_API_KEY', 'DELETE_AUTH_CERT', 'DELETE_AUTH_KEY',
+            'DELETE_CLIENT', 'DELETE_CLIENT_INTERNAL_CERT', 'DELETE_ENDPOINT', 'DELETE_KEY', 'DELETE_LOCAL_GROUP',
+            'DELETE_SIGN_CERT', 'DELETE_SIGN_KEY', 'DELETE_TSP', 'DELETE_WSDL', 'DIAGNOSTICS', 'DOWNLOAD_ANCHOR',
+            'EDIT_ACL_SUBJECT_OPEN_SERVICES', 'EDIT_CLIENT_INTERNAL_CONNECTION_TYPE', 'EDIT_ENDPOINT_ACL',
+            'EDIT_KEY_FRIENDLY_NAME', 'EDIT_LOCAL_GROUP_DESC', 'EDIT_LOCAL_GROUP_MEMBERS', 'EDIT_OPENAPI3',
+            'EDIT_OPENAPI3_ENDPOINT', 'EDIT_REST', 'EDIT_SERVICE_ACL', 'EDIT_SERVICE_PARAMS',
+            'EDIT_TOKEN_FRIENDLY_NAME', 'EDIT_WSDL', 'ENABLE_DISABLE_WSDL', 'EXPORT_INTERNAL_TLS_CERT',
+            'GENERATE_AUTH_CERT_REQ', 'GENERATE_INTERNAL_TLS_CSR', 'GENERATE_INTERNAL_TLS_KEY_CERT', 'GENERATE_KEY',
+            'GENERATE_SIGN_CERT_REQ', 'IMPORT_AUTH_CERT', 'IMPORT_INTERNAL_TLS_CERT', 'IMPORT_SIGN_CERT', 'INIT_CONFIG',
+            'REFRESH_OPENAPI3', 'REFRESH_REST', 'REFRESH_WSDL', 'RESTORE_CONFIGURATION', 'REVOKE_API_KEY',
+            'SEND_AUTH_CERT_DEL_REQ', 'SEND_AUTH_CERT_REG_REQ', 'SEND_CLIENT_DEL_REQ', 'SEND_CLIENT_REG_REQ',
+            'SEND_OWNER_CHANGE_REQ', 'UPDATE_API_KEY', 'UPLOAD_ANCHOR', 'VIEW_ACL_SUBJECT_OPEN_SERVICES', 'VIEW_ANCHOR',
+            'VIEW_API_KEYS', 'VIEW_APPROVED_CERTIFICATE_AUTHORITIES', 'VIEW_AUTH_CERT', 'VIEW_CLIENTS',
+            'VIEW_CLIENT_ACL_SUBJECTS', 'VIEW_CLIENT_DETAILS', 'VIEW_CLIENT_INTERNAL_CERTS',
+            'VIEW_CLIENT_INTERNAL_CERT_DETAILS', 'VIEW_CLIENT_INTERNAL_CONNECTION_TYPE', 'VIEW_CLIENT_LOCAL_GROUPS',
+            'VIEW_CLIENT_SERVICES', 'VIEW_ENDPOINT', 'VIEW_ENDPOINT_ACL', 'VIEW_INTERNAL_TLS_CERT', 'VIEW_KEYS',
+            'VIEW_MEMBER_CLASSES', 'VIEW_SECURITY_SERVERS', 'VIEW_SERVICE_ACL', 'VIEW_SIGN_CERT', 'VIEW_SYS_PARAMS',
+            'VIEW_TSPS', 'VIEW_UNKNOWN_CERT', 'VIEW_VERSION', 'VIEW_XROAD_INSTANCES'
+        ]
+    )
+
+
+class InitTestData:
+    all_initialized = InitializationStatus(True, True, True, TokenInitStatus.INITIALIZED)
+
+
+class DiagnosticsTestData:
+    global_ok_success = GlobalConfDiagnostics(
+        status_class="OK",
+        status_code="SUCCESS",
+        prev_update_at=datetime.now(),
+        next_update_at=datetime.now() + timedelta(minutes=5)
+    )
+
+
+class TokenTestData:
+    token_keyless = Token(
+        available=True,
+        id=0,
+        logged_in=True,
+        name='softToken-0',
+        possible_actions=None,
+        read_only=False,
+        saved_to_configuration=True,
+        serial_number=None,
+        status=TokenStatus.OK,
+        token_infos=[{'key': 'Type'}, {'value': 'Software'}],
+        type=TokenType.SOFTWARE,
+        keys=[]
+    )
+
+
+class StatusTestData:
+    server_status_unconnected = ServerStatus(
+        security_server_name='nameofss',
+        connectivity_status=(False, 'Failure for test'),
+    )
+
+    server_status_uninitialized_global_failing = ServerStatus(
+        security_server_name='nameofss',
+        connectivity_status=(True, ''),
+        roles_status=StatusRoles(permitted=True, roles=['ROLE_XROAD_SYSTEM_ADMINISTRATOR', 'ROLE_XROAD_SECURITY_OFFICER']),
+        version_status=StatusVersion(version="6.25.0"),
+        global_status=StatusGlobal(
+            class_="FAIL",
+            code="INTERNAL",
+            updated=DiagnosticsTestData.global_ok_success.prev_update_at,
+            refresh=DiagnosticsTestData.global_ok_success.next_update_at
+        ),
+        server_init_status=StatusServerInitialization()
+    )
+
+    server_status_essentials_complete = ServerStatus(
+        security_server_name='nameofss',
+        connectivity_status=(True, ''),
+        roles_status=StatusRoles(permitted=True, roles=UserTestData.with_all_grants.roles),
+        version_status=StatusVersion(version="6.25.0"),
+        global_status=StatusGlobal(
+            class_=DiagnosticsTestData.global_ok_success.status_class,
+            code=DiagnosticsTestData.global_ok_success.status_code,
+            updated=DiagnosticsTestData.global_ok_success.prev_update_at,
+            refresh=DiagnosticsTestData.global_ok_success.next_update_at
+        ),
+        server_init_status=StatusServerInitialization(
+            id_="TEST:VOG:6666:SECS",
+            has_anchor=True,
+            has_server_code=True,
+            server_code='SECS',
+            has_server_owner=True,
+            server_owner='6666',
+            token_init_status=TokenInitStatus.INITIALIZED
+        ),
+        timestamping_status=[StatusServerTimestamping(name='named-tsa', url='https://some.where.com')],
+        token_status=StatusToken(
+            id_=str(TokenTestData.token_keyless.id),
+            name=TokenTestData.token_keyless.name,
+            status=TokenTestData.token_keyless.status,
+            logged_in=TokenTestData.token_keyless.logged_in
+        ),
+        status_keys=StatusKeys(
+            key_count=2,
+            sign_key_count=1,
+            auth_key_count=1,
+            has_toolkit_sign_key=True,
+            toolkit_sign_key_id='5D3C550E99D06D8C2D6722996B22A5470EA353B6',
+            has_sign_key=True,
+            has_toolkit_auth_key=True,
+            toolkit_auth_key_id='8798F7D899EDCC8D5777772AFA5C189B653CB470',
+            has_auth_key=True
+        ),
+        status_csrs=StatusCsrs(
+            sign_csr_count=0,
+            auth_csr_count=0,
+            has_toolkit_sign_csr=False,
+            has_sign_csr=False,
+            has_toolkit_auth_csr=False,
+            has_auth_csr=False
+        ),
+        status_certs=StatusCerts(
+            has_sign_cert=True,
+            has_toolkit_sign_cert=True,
+            toolkit_sign_cert_hash="662C9B4B0D48CABAB2EDC72BC5DF3CF789A066F5",
+            has_auth_cert=True,
+            auth_cert_actions=[PossibleAction.DISABLE, PossibleAction.UNREGISTER],
+            has_toolkit_auth_cert=True,
+            toolkit_auth_cert_hash="8005BAC40B5373B1A8484B72C059AC9DBA23A741",
+            toolkit_auth_cert_actions=[PossibleAction.DISABLE, PossibleAction.UNREGISTER],
+            has_registered_auth_cert=True
+        )
+    )
+
+    @staticmethod
+    def server_status_essentials_complete_token_logged_out():
+        server_status = copy.deepcopy(StatusTestData.server_status_essentials_complete)
+        server_status.token_status.logged_in = False
+        return server_status
 
 
 # Requires all server status in first list to be uninitialized and all in second list to be
@@ -95,20 +247,32 @@ def perform_test_ca_sign(test_ca_sign_url, certfile_loc, _type):
     return response.content.decode("ascii")
 
 
-# Returns service descriptions for given client
-def get_service_description(config, client_id):
-    service_description = requests.get(
-        config["security_server"][0]["url"] + "/clients/" + client_id + "/service-descriptions",
-        None,
-        headers={'Authorization': config["security_server"][0]["api_key"], 'accept': 'application/json'},
+# Performs GET to given API url, making use of given api-key for Authorization header, returns response as JSON dict.
+def api_GET(api_url, api_path, api_key):
+    full_url = api_url + "/" + api_path
+    response = requests.get(
+        full_url,
+        headers={'Authorization': api_key, 'accept': 'application/json'},
         verify=False)
-    service_description_json = json.loads(str(service_description.content, 'utf-8').strip())
-    return service_description_json[0]
+
+    if response.status_code != 200:
+        raise Exception("Failed /" + full_url + " retrieval, status " + str(response.status_code) + ": " + str(response.reason))
+
+    return json.loads(str(response.content, 'utf-8').strip())
+
+
+# Returns service description for given client
+def get_service_description(config, client_id):
+    return api_GET(
+            config["security_server"][0]["url"],
+            "clients/" + client_id + "/service-descriptions",
+            config["security_server"][0]["api_key"]
+        )[0]
 
 
 # Returns client
 def get_client(config):
-    conn_type = BaseController.convert_swagger_enum(ConnectionType, config['security_server'][0]['clients'][0]['connection_type'])
+    conn_type = convert_swagger_enum(ConnectionType, config['security_server'][0]['clients'][0]['connection_type'])
     member_class = config['security_server'][0]['clients'][0]['member_class']
     member_code = config['security_server'][0]['clients'][0]['member_code']
     subsystem_code = config['security_server'][0]['clients'][0]['subsystem_code']
@@ -159,4 +323,4 @@ def auth_cert_registration_global_configuration_update_received(config):
 
     response = json.loads(result.content)
     registered_auth_keys = list(filter(registered_auth_key, response['keys']))
-    return True if registered_auth_keys else False
+    return bool(registered_auth_keys)

--- a/xrdsst/api_client/api_client.py
+++ b/xrdsst/api_client/api_client.py
@@ -23,6 +23,7 @@ import six
 from six.moves.urllib.parse import quote
 
 from xrdsst import models
+from xrdsst.api_client.rate_limit import limit_rate
 from xrdsst.configuration.configuration import Configuration
 from xrdsst.rest import rest
 
@@ -91,6 +92,20 @@ class ApiClient(object):
         self.default_headers[header_name] = header_value
 
     def __call_api(
+            self, resource_path, method, path_params=None,
+            query_params=None, header_params=None, body=None, post_params=None,
+            files=None, response_type=None, auth_settings=None,
+            _return_http_data_only=None, collection_formats=None,
+            _preload_content=True, _request_timeout=None):
+
+        limit_rate('/'.join(self.configuration.host.split('/')[:3]))
+
+        return self.__ratelimited_call_api(
+            resource_path, method, path_params, query_params, header_params, body, post_params, files, response_type,
+            auth_settings, _return_http_data_only, collection_formats, _preload_content, _request_timeout
+        )
+
+    def __ratelimited_call_api(
             self, resource_path, method, path_params=None,
             query_params=None, header_params=None, body=None, post_params=None,
             files=None, response_type=None, auth_settings=None,

--- a/xrdsst/api_client/rate_limit.py
+++ b/xrdsst/api_client/rate_limit.py
@@ -1,0 +1,43 @@
+import datetime
+import logging
+import threading
+import time
+
+_SS_RATE_LIMIT_SECOND = 20
+_SS_RATE_LIMIT_MINUTE = 600
+_SS_API_CLIENT_CALLS = {}  # host : { 'calls' : List(datetime), 'lock' : Lock }
+_RATELIMITER_LOCK = threading.Lock()
+
+
+def limit_rate(schemed_host):
+    def _excess_rates(schemed_host):
+        calls = _SS_API_CLIENT_CALLS[schemed_host]['calls']
+
+        atm = datetime.datetime.now()
+        min_calls = list(filter(lambda dt: (atm - dt) < datetime.timedelta(seconds=60), calls))
+        sec_calls = list(filter(lambda dt: (atm - dt) < datetime.timedelta(seconds=1), calls))
+
+        calls.clear()
+        calls.extend(min_calls)
+
+        limit_sec_exceeded = len(sec_calls) >= _SS_RATE_LIMIT_SECOND
+        limit_min_exceeded = len(min_calls) >= _SS_RATE_LIMIT_MINUTE
+
+        return limit_sec_exceeded, limit_min_exceeded
+
+    with _RATELIMITER_LOCK:
+        if not _SS_API_CLIENT_CALLS.get(schemed_host):
+            _SS_API_CLIENT_CALLS[schemed_host] = {}
+            _SS_API_CLIENT_CALLS[schemed_host]['lock'] = threading.Lock()
+            _SS_API_CLIENT_CALLS[schemed_host]['calls'] = []
+
+    with _SS_API_CLIENT_CALLS[schemed_host]['lock']:
+        sleep_time = 0
+        if any(_excess_rates(schemed_host)):
+            time.sleep(1)
+            sleep_time += 1
+
+        if sleep_time > 0:
+            logging.debug("Rate limit nap of " + str(sleep_time) + " seconds for '" + schemed_host + "'.")
+
+        _SS_API_CLIENT_CALLS[schemed_host]['calls'].append(datetime.datetime.now())

--- a/xrdsst/controllers/auto.py
+++ b/xrdsst/controllers/auto.py
@@ -1,5 +1,10 @@
+import copy
+
 from cement import ex
 from xrdsst.controllers.base import BaseController
+from xrdsst.controllers.status import StatusController
+from xrdsst.core.conf_keys import ConfKeysRoot, ConfKeysSecurityServer
+from xrdsst.core.util import op_node_to_ctr_cmd_text
 from xrdsst.resources.texts import texts
 
 
@@ -12,20 +17,61 @@ class AutoController(BaseController):
 
     @ex(help='autoconfig', hide=True)
     def _default(self):
-        config_file = self.load_config()
-        self._doit(config_file)
+        active_config = self.load_config()
+        self._auto(active_config)
 
-    def _doit(self, config_file):
-        self.init_logging(config_file)
-        self.auto_ss()
+    def _auto(self, active_config):
+        self.init_logging(active_config)
+        all_server_config = copy.deepcopy(active_config)
+        for i in range(0, len(all_server_config[ConfKeysRoot.CONF_KEY_ROOT_SERVER])):
+            single_server_config = all_server_config[ConfKeysRoot.CONF_KEY_ROOT_SERVER][i:(i+1)]
+            active_config[ConfKeysRoot.CONF_KEY_ROOT_SERVER] = single_server_config
+            self._single_server_auto(active_config)
 
-    def auto_ss(self):
+    def _single_server_auto(self, active_config):
+        self.app.auto_apply = True
+        ssn = active_config[ConfKeysRoot.CONF_KEY_ROOT_SERVER][0][ConfKeysSecurityServer.CONF_KEY_NAME]
+
+        self.update_op_statuses(active_config)
+
+        first_status = self.app.OP_GRAPH.nodes[self.app.OP_DEPENDENCY_LIST[0]]['servers'][ssn]['status']
+        if not first_status.connectivity_status[0]:
+            self.log_info("SKIPPED AUTO ->'" + ssn + "' no connectivity, (" + first_status.connectivity_status[1] + ").")
+            return
+
         for dep_op in self.app.OP_DEPENDENCY_LIST:
             op_node = self.app.OP_GRAPH.nodes[dep_op]
             if op_node.get('operation'):
                 if not op_node['controller'] in self.app.Meta.handlers:
                     raise Exception("No registered controller " + str(op_node['controller']) + " found.")
 
+                # Prep
+                op_text = op_node_to_ctr_cmd_text(self.app.OP_GRAPH, dep_op)
+                done_at_start = op_node['is_done'](ssn)
+                self.log_info("AUTO ['" + op_text + "']->'" + ssn + "'" + (" (redo) " if done_at_start else ''))
+
+                # Exec
                 ctr = op_node['controller']()
                 ctr.app = self.app
+                ctr.load_config = (lambda: active_config)
                 op_node['operation'](ctr)
+
+                # Eval outcome
+                self.update_op_statuses(active_config)
+                done_at_end = op_node['is_done'](ssn)
+
+                if not done_at_end:
+                    self.log_info(
+                        "AUTO ['" + op_text + "'] completion was NOT detected.\n"
+                        "Some operations require waiting for global configuration renewal.")
+                    o_ix = self.app.OP_DEPENDENCY_LIST.index(dep_op)
+                    next_op = self.app.OP_DEPENDENCY_LIST[o_ix+1:o_ix+2]
+                    if next_op:
+                        self.log_info("Next AUTO operation would have been ['" + op_node_to_ctr_cmd_text(self.app.OP_GRAPH, next_op[0]) + "'].")
+                    break
+
+        self.log_info("AUTO ['status']->'" + ssn + "' AT THE END OF AUTOCONFIGURATION.")
+        status_controller = StatusController()
+        status_controller.app = self.app
+        status_controller.load_config = (lambda: active_config)
+        status_controller._default()

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -1,17 +1,28 @@
 import atexit
+import copy
+import functools
+import inspect
 import json
+import sys
+
+import networkx
 import os
 import logging
 import random
 import string
 import subprocess
+import xrdsst
 import yaml
+
 from cement import Controller
 from cement.utils.version import get_version_banner
 from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlparse
+
 from definitions import ROOT_DIR
+from xrdsst.core.conf_keys import validate_conf_keys, ConfKeysSecurityServer, ConfKeysRoot
+from xrdsst.core.util import op_node_to_ctr_cmd_text, RE_API_KEY_HEADER
 from xrdsst.core.version import get_version
 from xrdsst.resources.texts import texts
 from xrdsst.configuration.configuration import Configuration
@@ -28,9 +39,12 @@ class BaseController(Controller):
             (['-v', '--version'], {'action': 'version', 'version': BANNER})
         ]
 
+    @staticmethod
+    def get_server_status(api_config, ss_config):
+        return xrdsst.core.api_util.status_server(api_config, ss_config)  # Allow somewhat sane mocking.
+
     config_file = os.path.join(ROOT_DIR, "config/base.yaml")
     config = None
-    api_key_default = "X-Road-apikey token=<API_KEY>"
     api_key_id = {}
 
     def _pre_argument_parsing(self):
@@ -44,7 +58,7 @@ class BaseController(Controller):
                            default=os.path.join(ROOT_DIR, "config/base.yaml"))  # TODO extract to consts after settling on naming
 
     def create_api_key(self, roles_list, config, security_server):
-        self.log_info('Creating API key for security server: ' + security_server['name'])
+        self.log_debug('Creating API key for security server: ' + security_server['name'])
         roles = []
         for role in roles_list:
             roles.append(role)
@@ -59,12 +73,124 @@ class BaseController(Controller):
                 api_key_json = json.loads(str(process.stdout, 'utf-8').strip())
                 self.api_key_id[security_server['name']] = api_key_json["id"]
                 self.log_info('API key \"' + api_key_json["key"] + '\" for security server ' + security_server['name'] +
-                              ' created successfully')
+                              ' created.')
                 return api_key_json["key"]
             except Exception as err:
                 self.log_api_error('BaseController->create_api_key:', err)
         else:
             raise Exception("SSH private key file does not exists")
+
+    # Returns true if controller is being invoked in autoconfiguration mode.
+    def is_autoconfig(self):
+        return self.app.auto_apply
+
+    # Returns operation graph node, deduced from call frame at given depth,
+    def _op_node(self, depth):
+        if not issubclass(self.__class__, BaseController):  # Nothing but error.
+            return None
+
+        operation = getattr(self.__class__, inspect.stack()[depth].function)
+        g = self.app.OP_GRAPH
+
+        for g_node in g:
+            node = g.nodes[g_node]
+            if node.get('operation') == operation:
+                return g_node
+
+        return None
+
+    # Returns operational dependency chain for caller that is itself controller command.
+    # Calling convention: immediately from the controller command function that invoked by Cement.
+    def op_path(self):
+        if not issubclass(self.__class__, BaseController):  # Nothing but error.
+            return None
+
+        op_node = self._op_node(2)
+        if not op_node:
+            return []
+
+        return networkx.shortest_path(self.app.OP_GRAPH, self.app.OP_DEPENDENCY_LIST[0], op_node)
+
+    # Updates operation graph with server-side /operation statuses/ AND /API config/ for security servers configured.
+    def update_op_statuses(self, active_config):
+        g = self.app.OP_GRAPH
+        for g_node in g:
+            node = g.nodes[g_node]
+            if node.__contains__('servers'):
+                node['servers'].clear()
+
+        for security_server in active_config["security_server"]:
+            ssn = security_server['name']
+            api_config = self.initialize_basic_config_values(security_server, active_config)
+            status = self.get_server_status(api_config, security_server)
+
+            for g_node in g:
+                node = g.nodes[g_node]
+                node['servers'][ssn] = {'api_config': api_config, 'status': status}
+
+    # Given active configuration and full operation path to single operation, returns regrouped configuration and
+    # the detailed reachability status for those configured servers for which last operation on the path is unreachable.
+    def regroup_server_ops(self, active_config, op_full_path):
+        self.update_op_statuses(active_config)
+
+        reachable_config = copy.deepcopy(active_config)  # Retains only security servers with reachable end-operation.
+        # NB! Depending on server status, these (un)reachable operations will not necessarily be successive.
+        reachable_ops = {}
+        unreachable_ops = {}
+        skipped_servers = []
+
+        for security_server in active_config["security_server"]:
+            ssn = security_server['name']
+            conn_status = self.app.OP_GRAPH.nodes[self.app.OP_DEPENDENCY_LIST[0]]['servers'][ssn]['status'].connectivity_status
+            reachable_ops[ssn] = []
+            unreachable_ops[ssn] = []
+
+            for oop in op_full_path[:-1]:
+                performed = self.app.OP_GRAPH.nodes[oop]['is_done'](ssn)
+                (reachable_ops if performed else unreachable_ops)[ssn].append(oop)
+
+            if len(unreachable_ops[ssn]) > 0 or not conn_status[0]:
+                for rssc in reachable_config["security_server"]:
+                    if ssn == rssc['name']:
+                        skipped_servers.append(rssc)
+                        reachable_config['security_server'].remove(rssc)
+
+        skip_details = {}  # Python 3.6+ retains insertion order, as desired here.
+        for skipped_server in skipped_servers:
+            skip_details[skipped_server['name']] = {
+                'reachable_ops': reachable_ops[skipped_server['name']],
+                'unreachable_ops': unreachable_ops[skipped_server['name']]
+            }
+
+        return reachable_config, skip_details
+
+    # Given active configuration and full operation path to single operation, returns configuration exclusively with
+    # security servers which have valid operation configuration defined.
+    def validate_op_config(self, active_config):
+        from xrdsst.main import VALIDATORS
+
+        validating_config = copy.deepcopy(active_config)  # Keep security servers with validating operation config only.
+        op_node = self._op_node(2)
+        op_cmd_text = op_node_to_ctr_cmd_text(self.app.OP_GRAPH, op_node)
+        skipped_servers = []
+        errors = {}
+
+        for security_server in active_config["security_server"]:
+            ssn = security_server['name']
+            errors[ssn] = []
+            if not VALIDATORS[op_node](security_server, op_cmd_text, errors[ssn]):
+                for ss in validating_config["security_server"]:
+                    if ssn == ss['name']:
+                        skipped_servers.append(ss)
+                        validating_config['security_server'].remove(ss)
+
+        skip_details = {}  # Python 3.6+ retains insertion order, as desired here.
+        for skipped_server in skipped_servers:
+            skip_details[skipped_server['name']] = {
+                'errors': errors[skipped_server['name']]
+            }
+
+        return validating_config, skip_details
 
     # Render arguments differ for back-ends, one approach.
     def render(self, render_data):
@@ -77,17 +203,29 @@ class BaseController(Controller):
         return self.app.output.Meta.label == 'tabulate'
 
     def get_api_key(self, conf, security_server):
-        config = conf if conf else self.config
-        roles_list = config["api_key"][0]["roles"]
+        # Use API key configured for security server, if valid.
+        ss_api_key = security_server.get(ConfKeysSecurityServer.CONF_KEY_API_KEY)
+        has_valid_ss_api_key = RE_API_KEY_HEADER.fullmatch(ss_api_key)
+        if has_valid_ss_api_key:
+            self.log_debug("Using existing API key for security server: '" + security_server['name'] + "'")
+            return ss_api_key
+
+        # Use temporary API key, if already created for any operation.
+        if self.app.api_keys.get(security_server.get(ConfKeysSecurityServer.CONF_KEY_NAME)):
+            return self.app.api_keys[security_server[ConfKeysSecurityServer.CONF_KEY_NAME]]
+
+        # Fallback attempt to create the (temporary) API key, if there seems to be SSH access configured.
         api_key = None
-        if security_server["api_key"] != self.api_key_default:
-            self.log_info('API key for security server: ' + security_server['name'] + ' has already been created')
-            api_key = security_server["api_key"]
-        else:
+        config = conf if conf else self.config
+
+        if config.get(ConfKeysRoot.CONF_KEY_ROOT_API_KEY):
+            roles_list = config[ConfKeysRoot.CONF_KEY_ROOT_API_KEY][0]["roles"]
             try:
                 api_key = 'X-Road-apikey token=' + self.create_api_key(roles_list, conf, security_server)
+                self.app.api_keys[security_server[ConfKeysSecurityServer.CONF_KEY_NAME]] = api_key
             except Exception as err:
                 self.log_api_error('BaseController->get_api_key:', err)
+
         return api_key
 
     @staticmethod
@@ -131,18 +269,106 @@ class BaseController(Controller):
             exit_messages.append("Activities logged into '" + log_file_name + "'.")
             atexit.register(lambda: print(*exit_messages, sep='\n'))
 
-
     def load_config(self, baseconfig=None):
+        # Add errors to /dict_err_lists/ at given key for /sec_server_configs/ that do not have required /key/ defined.
+        def require_conf_key(key, sec_server_configs, dict_err_lists):
+            for i in range(0, len(sec_server_configs)):
+                if not sec_server_configs[i].get(key) or not sec_server_configs[i][key]:
+                    dict_err_lists[key].append(
+                        "security_server[" + str(i + 1) + "]" + " missing required '" + key + "' definition."
+                    )
+
+        # Add errors to /dict_err_lists/ if /sec_server_configs/ does not have UNIQUE /key/ VALUE for all entries.
+        def require_unique_conf_keys(key, sec_server_configs, dict_err_lists):
+            values = {x[key] for x in sec_server_configs}
+            if len(values) == len(sec_server_configs):
+                return
+
+            key_counts = {x: 0 for x in values}
+            for x in sec_server_configs:
+                key_counts[x[key]] += 1
+
+            duplicates = [x for x in key_counts.keys() if key_counts[x] > 1]
+            detected = set()
+            for z in range(0, len(sec_server_configs)):
+                # Append all duplicated value occurence messages in sequence
+                if sec_server_configs[z][key] in duplicates and sec_server_configs[z][key] not in detected:
+                    for y in range(0, len(sec_server_configs)):
+                        if str(sec_server_configs[z][key]) == str(sec_server_configs[y][key]):
+                            dict_err_lists[key].append(
+                                ConfKeysRoot.CONF_KEY_ROOT_SERVER + "[" + str(y + 1) + "] '" + key +
+                                "' value '" + str(sec_server_configs[y][key]) + "' is non-unique."
+                            )
+                    detected.add(str(sec_server_configs[z][key]))
+
         if not baseconfig:
             baseconfig = self.app.pargs.configfile
             self.config_file = baseconfig
+
         if not os.path.exists(baseconfig):
-            self.log_info("Cannot load config '" + baseconfig + "'")
+            self.log_info(texts['message.file.not.found'].format(baseconfig))
             self.app.close(os.EX_CONFIG)
-        else:
+            return None
+
+        try:
             with open(baseconfig, "r") as yml_file:
-                self.config = yaml.load(yml_file, Loader=yaml.FullLoader)
+                self.config = yaml.safe_load(yml_file)
             self.config_file = baseconfig
+        except IOError as io_err:
+            self.log_info(io_err)
+            self.log_info(texts["message.file.unreadable"].format(baseconfig))
+            self.app.close(os.EX_CONFIG)
+            return None
+        except yaml.YAMLError as other_yaml_err:
+            self.log_info(texts["message.config.unparsable"].format(other_yaml_err))
+            self.app.close(os.EX_CONFIG)
+            return None
+
+        # Perform the basic (key-level only) configuration validation.
+        if self.config:
+            conf_key_errors = validate_conf_keys(self.config)
+            for conf_key_error in conf_key_errors:
+                padding = (len(conf_key_error[0]) - len(conf_key_error[1]) - 1)
+                print(conf_key_error[0], 'NOT AMONG', file=sys.stderr)
+                for known_key in sorted(conf_key_error[2]):
+                    print(' ' * (len(conf_key_error[1]) + padding + 1), known_key, file=sys.stderr)
+                print('', file=sys.stderr)
+
+            if conf_key_errors:
+                self.log_info("Invalid configuration keys encountered in '{}'.".format(self.config_file))
+                self.app.close(os.EX_CONFIG)
+                return None
+
+        # Without server definitions, exit -- can become conditional when/if interactive mode is implemented & enabled.
+        if not self.config or not self.config.get(ConfKeysRoot.CONF_KEY_ROOT_SERVER):
+            if self.is_output_tabulated():  # Totally ineffectual, do not log.
+                print(texts['message.config.serverless'].format(baseconfig), file=sys.stderr)
+            self.app.close(os.EX_CONFIG)
+            return None
+
+        # Defined security servers HAVE TO have non-empty name and url defined!
+        conf_security_servers = self.config[ConfKeysRoot.CONF_KEY_ROOT_SERVER]
+        errors = {ConfKeysSecurityServer.CONF_KEY_NAME: [], ConfKeysSecurityServer.CONF_KEY_URL: []}
+        require_conf_key(ConfKeysSecurityServer.CONF_KEY_NAME, conf_security_servers, errors)
+        require_conf_key(ConfKeysSecurityServer.CONF_KEY_URL, conf_security_servers, errors)
+
+        if errors[ConfKeysSecurityServer.CONF_KEY_NAME] or errors[ConfKeysSecurityServer.CONF_KEY_URL]:
+            print(*errors[ConfKeysSecurityServer.CONF_KEY_NAME], sep='\n', file=sys.stderr)
+            print(*errors[ConfKeysSecurityServer.CONF_KEY_URL], sep='\n', file=sys.stderr)
+            self.app.close(os.EX_CONFIG)
+            return None
+
+        # Potential live disaster recipe is when configured security servers' 'name' or 'url' somewhere collude
+        # in the provided configuration file. So do the extra check and refuse to run if such situation detected.
+        require_unique_conf_keys(ConfKeysSecurityServer.CONF_KEY_NAME, conf_security_servers, errors)
+        require_unique_conf_keys(ConfKeysSecurityServer.CONF_KEY_URL, conf_security_servers, errors)
+
+        if errors[ConfKeysSecurityServer.CONF_KEY_NAME] or errors[ConfKeysSecurityServer.CONF_KEY_URL]:
+            print(*errors[ConfKeysSecurityServer.CONF_KEY_NAME], sep='\n', file=sys.stderr)
+            print(*errors[ConfKeysSecurityServer.CONF_KEY_URL], sep='\n', file=sys.stderr)
+            self.app.close(os.EX_CONFIG)
+            return None
+
         return self.config
 
     def initialize_basic_config_values(self, security_server, config=None):
@@ -152,15 +378,45 @@ class BaseController(Controller):
         configuration.verify_ssl = False
         return configuration
 
+    # Produces INFO level log and console printout about unconfigured servers details when executing single operation
+    # (last operation in given /full_op_path/).
+    def log_skipped_op_deps_unmet(self, full_op_path, unconfigured_servers):
+        op_text = functools.partial(op_node_to_ctr_cmd_text, self.app.OP_GRAPH)
+        for ssn in unconfigured_servers:
+            conn_status = self.app.OP_GRAPH.nodes[full_op_path[-1]]['servers'][ssn]['status'].connectivity_status
+            if not conn_status[0]:
+                skip_msg = texts['message.skipped'].format(ssn) + ": no connectivity ({}).".format(str(conn_status[1]))
+                self.log_info(skip_msg)
+                continue
+            hr_reachable = list(map(op_text, unconfigured_servers[ssn]['reachable_ops']))
+            hr_unreachable = list(map(op_text, unconfigured_servers[ssn]['unreachable_ops']))
+            skip_msg = \
+                texts['message.skipped'].format(ssn) + ":" + \
+                ((" has " + str(hr_reachable) + " performed but also") if hr_reachable else '') + \
+                " needs " + str(hr_unreachable) + \
+                " completion before continuing with requested ['" + op_text(full_op_path[-1]) + "']"
+            self.log_info(skip_msg)
+
+    def log_skipped_op_conf_invalid(self, invalid_conf_servers):
+        for ssn in invalid_conf_servers.keys():
+            skip_msg = \
+                texts['message.skipped'].format(ssn) + ":\n" + (' ' * 8) + \
+                ("\n" + (' ' * 8)).join(invalid_conf_servers[ssn]['errors'])
+            self.log_info(skip_msg)
+
     @staticmethod
     def log_api_error(api_method, exception):
         logging.error("Exception calling " + api_method + ": " + str(exception))
-        print("Exception calling " + api_method + ": " + str(exception))
+        print("Exception calling " + api_method + ": " + str(exception), file=sys.stderr)
 
     @staticmethod
     def log_info(message):
         logging.info(message)
         print(message)
+
+    @staticmethod
+    def log_debug(message):
+        logging.debug(message)
 
     @staticmethod
     def security_server_address(security_server):
@@ -171,10 +427,3 @@ class BaseController(Controller):
         :return: IP/host deduced from security server URL
         """
         return urlparse(security_server['url']).netloc.split(':')[0]  # keep the case, unlike with '.hostname'
-
-    @staticmethod
-    def convert_swagger_enum(_type, value):
-        valid_values = list(filter(lambda x: x.isupper(), vars(_type)))
-        if value not in valid_values:
-            raise SyntaxWarning("Invalid value '" + value + "' for " + str(_type.__name__) + ", need " + str(valid_values))
-        return value

--- a/xrdsst/controllers/status.py
+++ b/xrdsst/controllers/status.py
@@ -1,9 +1,7 @@
-import xrdsst
-
 from cement import ex
 
 from xrdsst.controllers.base import BaseController
-from xrdsst.core.api_util import ServerStatus
+from xrdsst.core.api_util import ServerStatus, status_server
 from xrdsst.resources.texts import texts
 
 
@@ -136,5 +134,4 @@ class StatusController(BaseController):
 
     @staticmethod
     def remote_status(ss_configuration, security_server):
-        # TODO: maybe should do some wiggle with reachability / accessibility here in this place???
-        return xrdsst.core.api_util.status_server(ss_configuration, security_server)
+        return status_server(ss_configuration, security_server)

--- a/xrdsst/core/conf_keys.py
+++ b/xrdsst/core/conf_keys.py
@@ -1,0 +1,119 @@
+# Return list of configuration keys that are NOT among known ConfKeys*, in hierarchical representation
+def validate_conf_keys(xrdsst_conf):
+    # Return only configuration keys from ConfKey list class (CONF_KEY_)
+    def _keys_only(conf_key_X):
+        return {getattr(conf_key_X, x) for x in vars(conf_key_X) if x.startswith('CONF_KEY')}
+
+    # Return only used keys that are NOT among known ConfKeys
+    def _invalid(used_keys, conf_key_X):
+        return used_keys.difference(_keys_only(conf_key_X))
+
+    def _validate_conf_keys(xrdsst_conf_fragment, conf_key_X):
+        result = []
+        if isinstance(xrdsst_conf_fragment, dict):
+            fragment_keys = set(xrdsst_conf_fragment.keys())
+            invalid_fragment_keys = _invalid(fragment_keys, conf_key_X)
+            result.extend(map(lambda key: ('.' + key, key, _keys_only(conf_key_X)), invalid_fragment_keys))
+
+            for desc_key in {x for x in conf_key_X.descendant_conf_keys() if xrdsst_conf_fragment.get(x[0])}:
+                result.extend(map(
+                    lambda key: ('.' + desc_key[0] + str(key[0]), key[1], key[2]),
+                    _validate_conf_keys(xrdsst_conf_fragment[desc_key[0]], desc_key[1])
+                ))
+        elif isinstance(xrdsst_conf_fragment, list):
+            for i in range(0, len(xrdsst_conf_fragment)):
+                result.extend(map(
+                    lambda key: ('[' + str(i+1) + ']' + str(key[0]), key[1], key[2]),
+                    _validate_conf_keys(xrdsst_conf_fragment[i], conf_key_X)
+                ))
+
+        return result
+
+    return _validate_conf_keys(xrdsst_conf, ConfKeysRoot)
+
+
+# Known keys for xrdsst configuration file root.
+class ConfKeysRoot:
+    CONF_KEY_ROOT_API_KEY = 'api_key'
+    CONF_KEY_ROOT_SERVER = 'security_server'
+    CONF_KEY_ROOT_LOGGING = 'logging'
+
+    # Return the tuples ('child key', child conf keys class) for keys with descendants of their own
+    @staticmethod
+    def descendant_conf_keys():
+        return [
+            (ConfKeysRoot.CONF_KEY_ROOT_API_KEY, ConfKeysApiKey),
+            (ConfKeysRoot.CONF_KEY_ROOT_SERVER, ConfKeysSecurityServer),
+            (ConfKeysRoot.CONF_KEY_ROOT_LOGGING, ConfKeysLogging)
+        ]
+
+
+# Known keys for xrdsst configuration file security server API key creation section.
+class ConfKeysApiKey:
+    CONF_KEY_API_KEY_CREDENTIALS = 'credentials'
+    CONF_KEY_API_KEY_KEY = 'key'
+    CONF_KEY_API_KEY_ROLES = 'roles'
+    CONF_KEY_API_KEY_URL = 'url'
+
+    @staticmethod
+    def descendant_conf_keys():
+        return []
+
+
+# Known keys for xrdsst configuration file logging section.
+class ConfKeysLogging:
+    CONF_KEY_LOGGING_FILE = 'file'
+    CONF_KEY_LOGGING_LEVEL = 'level'
+
+    @staticmethod
+    def descendant_conf_keys():
+        return []
+
+
+# Known keys for xrdsst configuration file security server configuration section.
+class ConfKeysSecurityServer:
+    CONF_KEY_ANCHOR = 'configuration_anchor'
+    CONF_KEY_API_KEY = 'api_key'
+    CONF_KEY_CERTS = 'certificates'
+    CONF_KEY_CLIENTS = 'clients'
+    CONF_KEY_DN_C = 'owner_dn_country'
+    CONF_KEY_DN_ORG = 'owner_dn_org'
+    CONF_KEY_NAME = 'name'
+    CONF_KEY_MEMBER_CLASS = 'owner_member_class'
+    CONF_KEY_MEMBER_CODE = 'owner_member_code'
+    CONF_KEY_SERVER_CODE = 'security_server_code'
+    CONF_KEY_SOFT_TOKEN_ID = 'software_token_id'
+    CONF_KEY_SOFT_TOKEN_PIN = 'software_token_pin'
+    CONF_KEY_URL = 'url'
+
+    @staticmethod
+    def descendant_conf_keys():
+        return [
+            (ConfKeysSecurityServer.CONF_KEY_CLIENTS, ConfKeysSecServerClients)
+        ]
+
+
+# Known keys for xrdsst configuration file security server client configuration section.
+class ConfKeysSecServerClients:
+    CONF_KEY_SS_CLIENT_MEMBER_CLASS = 'member_class'
+    CONF_KEY_SS_CLIENT_MEMBER_CODE = 'member_code'
+    CONF_KEY_SS_CLIENT_SUBSYSTEM_CODE = 'subsystem_code'
+    CONF_KEY_SS_CLIENT_CONNECTION_TYPE = 'connection_type'
+    CONF_KEY_SS_CLIENT_SERVICE_DESCS = 'service_descriptions'
+
+    @staticmethod
+    def descendant_conf_keys():
+        return [
+            (ConfKeysSecServerClients.CONF_KEY_SS_CLIENT_SERVICE_DESCS, ConfKeysSecServerClientServiceDesc)
+        ]
+
+
+# Known keys for xrdsst configuration file security server client service descriptions configuration section.
+class ConfKeysSecServerClientServiceDesc:
+    CONF_KEY_SS_CLIENT_SERVICE_DESC_URL = 'url'
+    CONF_KEY_SS_CLIENT_SERVICE_DESC_REST_SERVICE_CODE = 'rest_service_code'
+    CONF_KEY_SS_CLIENT_SERVICE_DESC_TYPE = 'type'
+
+    @staticmethod
+    def descendant_conf_keys():
+        return []

--- a/xrdsst/core/util.py
+++ b/xrdsst/core/util.py
@@ -60,6 +60,7 @@ def is_ss_connectable(ss_url, sock_timeout=1):
     from socket import SOCK_STREAM, SHUT_RDWR, socket, AF_INET, error
     from urllib.parse import urlparse
     from urllib.error import URLError
+    from xrdsst.api_client.rate_limit import limit_rate
 
     def has_protocol_host_port(url):
         try:
@@ -78,6 +79,8 @@ def is_ss_connectable(ss_url, sock_timeout=1):
     url_netloc = urlparse(ss_url).netloc
     parts = url_netloc.split(':')
     host, port = parts[0], int(parts[1])
+
+    limit_rate('/'.join(ss_url.split('/')[:3]))
     try:
         s = socket(AF_INET, SOCK_STREAM)
         s.settimeout(sock_timeout)

--- a/xrdsst/core/util.py
+++ b/xrdsst/core/util.py
@@ -1,3 +1,19 @@
+import os
+import re
+
+# Regex of X-Road security server header for API key.
+RE_API_KEY_HEADER = re.compile(r"""
+    ^
+    X-Road-apikey[ ]token=
+    [a-f0-9]{8}-
+    [a-f0-9]{4}-
+    [a-f0-9]{4}-  # Do not fix UUID version
+    [a-f0-9]{4}-  # Do no validate first character separately
+    [a-f0-9]{12}
+    $
+""", re.VERBOSE | re.IGNORECASE)
+
+
 # Returns toolkit default AUTHENTICATION key label, given security server configuration
 def default_auth_key_label(security_server):
     return security_server['name'] + '-default-auth-key'
@@ -6,3 +22,70 @@ def default_auth_key_label(security_server):
 # Returns toolkit default SIGNING key label, given security server configuration
 def default_sign_key_label(security_server):
     return security_server['name'] + '-default-sign-key'
+
+
+# Returns human readable controller invocation operation for given operation graph and its named node.
+def op_node_to_ctr_cmd_text(g, node_name):
+    node = g.nodes[node_name]
+    if not node.get('controller'):
+        return ''
+
+    ccl = node.get('controller')
+    cop = node.get('operation')
+
+    try:
+        cop_name = getattr(cop, '__name__')
+    except AttributeError:
+        # Care for the annoying magic mocks... _extract_mock_name() is only in Python 3.7 apparently.
+        cop_name = cop.__dict__['_mock_name']
+
+    ctr_label = ccl.Meta.label
+    # Correct with default settings and conventions + saves lot of hassle from AST/inspect.
+    op_label = (cop_name.replace('_', '-').rstrip('-') if not cop_name.startswith('_') else '')
+
+    return ctr_label + ((' ' + op_label) if op_label else '')
+
+
+# Throws SyntaxWarning if /value/ is not among those in Swagger enum definition, returns same value otherwise.
+def convert_swagger_enum(_type, value):
+    valid_values = list(filter(lambda x: x.isupper(), vars(_type)))
+    if value not in valid_values:
+        raise SyntaxWarning("value '" + value + "' not in " + str(valid_values))
+    return value
+
+
+# Do fast (or slow :)) connection test for /ss_url/, allowing to set socket timeout, default is set to 1 second.
+# Returns tuple (is_connectable: bool, error_msg: str).
+def is_ss_connectable(ss_url, sock_timeout=1):
+    from socket import SOCK_STREAM, SHUT_RDWR, socket, AF_INET, error
+    from urllib.parse import urlparse
+    from urllib.error import URLError
+
+    def has_protocol_host_port(url):
+        try:
+            result = urlparse(url)
+            return (
+                    all([result.scheme, result.netloc]) and
+                    len(result.netloc.split(':')) == 2 and
+                    result.netloc.split(':')[1].isnumeric()
+            )
+        except URLError:
+            return False
+
+    if not has_protocol_host_port(ss_url):  # For security server deployments, port seems pure necessity
+        return False, "Unparsable scheme://host:port for '{}'.".format(ss_url)
+
+    url_netloc = urlparse(ss_url).netloc
+    parts = url_netloc.split(':')
+    host, port = parts[0], int(parts[1])
+    try:
+        s = socket(AF_INET, SOCK_STREAM)
+        s.settimeout(sock_timeout)
+        s.connect((host, port))
+        s.send("HTTP 1.1 /\n".encode('utf-8'))  # Just enough to get back error
+        s.recv(1)
+        s.shutdown(SHUT_RDWR)
+        s.close()
+        return True, ''
+    except error as err:
+        return False, os.strerror(err.errno)

--- a/xrdsst/core/util.py
+++ b/xrdsst/core/util.py
@@ -91,4 +91,4 @@ def is_ss_connectable(ss_url, sock_timeout=1):
         s.close()
         return True, ''
     except error as err:
-        return False, os.strerror(err.errno)
+        return False, os.strerror(err.errno) if err.errno else str(err)

--- a/xrdsst/core/validator.py
+++ b/xrdsst/core/validator.py
@@ -1,0 +1,228 @@
+import copy
+import os
+
+import cement.utils.fs
+
+from xrdsst.core.conf_keys import ConfKeysSecurityServer, ConfKeysSecServerClients, ConfKeysSecServerClientServiceDesc
+from xrdsst.core.util import convert_swagger_enum
+from xrdsst.models import ConnectionType, ServiceType
+
+
+def validator_msg_prefix(ss_config, operation):
+    return "'" + ss_config[ConfKeysSecurityServer.CONF_KEY_NAME] + "' [" + str(operation) + "]: "
+
+
+# Adds operation error for unfilled key to /errors/ and returns True (False) when requirements met (not met).
+def require_fill(key, ss_config, operation, errors):
+    val = ss_config.get(key)
+    if val is None:
+        errors.append(validator_msg_prefix(ss_config, operation) + "'" + key + "'" + " missing required value.")
+    return bool(val)
+
+
+# Adds operation error for (unfilled) / (not matching swagger enum) key to /errors/. Return True/False if valid/invalid.
+def require_swagger_enum_fill(type_, key, ss_config, operation, errors):
+    val = ss_config.get(key)
+
+    try:
+        convert_swagger_enum(type_, val)
+    except SyntaxWarning as syn_err:
+        errors.append(validator_msg_prefix(ss_config, operation) + "'" + key + "' " + str(syn_err))
+        return False
+
+    return True
+
+
+# Adds operation error into /errors/ for filled key if its value refers to unreadable or empty file or to a directory.
+# Returns True if no errors detected, False otherwise.
+def require_readable_file_path(key, ss_config, operation, errors):
+    if not require_fill(key, ss_config, operation, errors):
+        return False
+
+    config_file_path = ss_config[key]
+    file_path = cement.utils.fs.join_exists(config_file_path)
+    if not file_path[1]:
+        errors.append(validator_msg_prefix(ss_config, operation) + "'" + key + "'" + " references non-existent file '" + file_path[0] + "'.")
+        return False
+
+    if os.path.isdir(file_path[0]):
+        errors.append(validator_msg_prefix(ss_config, operation) + "'" + key + "'" + " references directory '" + file_path[0] + "'.")
+        return False
+
+    try:
+        fh = open(file_path[0], 'rb')
+        single_byte = fh.read(1)
+        fh.close()
+        if len(single_byte) != 1:
+            errors.append(validator_msg_prefix(ss_config, operation) + "'" + key + "'" + " references empty file '" + file_path[0] + "'.")
+            return False
+    except PermissionError:
+        errors.append(validator_msg_prefix(ss_config, operation) + "'" + key + "'" + " references unreadable file '" + file_path[0] + "'.")
+
+    return True
+
+
+def validate_config_init(ss_config, operation, errors):
+    err_cnt = len(errors)
+
+    require_fill(ConfKeysSecurityServer.CONF_KEY_MEMBER_CLASS, ss_config, operation, errors)
+    require_fill(ConfKeysSecurityServer.CONF_KEY_MEMBER_CODE, ss_config, operation, errors)
+    require_fill(ConfKeysSecurityServer.CONF_KEY_SERVER_CODE, ss_config, operation, errors)
+    require_fill(ConfKeysSecurityServer.CONF_KEY_SOFT_TOKEN_PIN, ss_config, operation, errors)
+    require_fill(ConfKeysSecurityServer.CONF_KEY_SOFT_TOKEN_ID, ss_config, operation, errors)
+    if require_fill(ConfKeysSecurityServer.CONF_KEY_ANCHOR, ss_config, operation, errors):
+        require_readable_file_path(ConfKeysSecurityServer.CONF_KEY_ANCHOR, ss_config, operation, errors)
+
+    return len(errors) <= err_cnt
+
+
+def validate_config_token_login(ss_config, operation, errors):
+    err_cnt = len(errors)
+
+    require_fill(ConfKeysSecurityServer.CONF_KEY_SOFT_TOKEN_PIN, ss_config, operation, errors)
+    require_fill(ConfKeysSecurityServer.CONF_KEY_SOFT_TOKEN_ID, ss_config, operation, errors)
+
+    return len(errors) <= err_cnt
+
+
+def validate_config_timestamp_init(ss_config, operation, errors):
+    # Timestamping service initialization uses only information from central server and security server
+    # and has no specific configuration file section.
+    return True
+
+
+def validate_config_token_init_keys(ss_config, operation, errors):
+    err_cnt = len(errors)
+
+    require_fill(ConfKeysSecurityServer.CONF_KEY_MEMBER_CLASS, ss_config, operation, errors)
+    require_fill(ConfKeysSecurityServer.CONF_KEY_MEMBER_CODE, ss_config, operation, errors)
+    require_fill(ConfKeysSecurityServer.CONF_KEY_SERVER_CODE, ss_config, operation, errors)
+    require_fill(ConfKeysSecurityServer.CONF_KEY_DN_C, ss_config, operation, errors)
+    require_fill(ConfKeysSecurityServer.CONF_KEY_DN_ORG, ss_config, operation, errors)
+    require_fill(ConfKeysSecurityServer.CONF_KEY_SOFT_TOKEN_ID, ss_config, operation, errors)
+
+    return len(errors) <= err_cnt
+
+
+def validate_config_cert_import(ss_config, operation, errors):
+    err_cnt = len(errors)
+
+    if not require_fill(ConfKeysSecurityServer.CONF_KEY_CERTS, ss_config, operation, errors):
+        # Since this is such a special case, amend the error message slightly for further clues.
+        errors.append(errors.pop() + " Submit downloaded CSRs for signing and specify received certificates accordingly.")
+    else:
+        # List conversion to dict is bit stupid here, but at the moment sufficient, if similar crops up, go multi-type with require_*.
+        certs_config = copy.deepcopy(ss_config[ConfKeysSecurityServer.CONF_KEY_CERTS])
+        cert_file_list_dict = {}
+        for cert_ix in range(0, len(certs_config)):
+            cert_file_list_dict[str(cert_ix + 1)] = certs_config[cert_ix]
+
+        for cert_ix in range(0, len(certs_config)):
+            cert_file_list_dict[ConfKeysSecurityServer.CONF_KEY_NAME] = (
+                ss_config[ConfKeysSecurityServer.CONF_KEY_NAME] + "." +
+                ConfKeysSecurityServer.CONF_KEY_CERTS + "[" + str(cert_ix + 1) + "]"
+            )
+
+            require_readable_file_path(str(cert_ix + 1), cert_file_list_dict, operation, errors)
+
+    return len(errors) <= err_cnt
+
+
+def validate_config_cert_register(ss_config, operation, errors):
+    # AUTH cert registration has no specific configuration file section / keys.
+    return True
+
+
+def validate_config_cert_activate(ss_config, operation, errors):
+    # AUTH cert activation has no specific configuration file section / keys.
+    return True
+
+
+# 'download-csrs' is not an operation, but define validation with same convention as for others, used separately.
+def validate_config_cert_download_csrs(ss_config, operation, errors):
+    err_cnt = len(errors)
+
+    require_fill(ConfKeysSecurityServer.CONF_KEY_SOFT_TOKEN_ID, ss_config, operation, errors)
+
+    return len(errors) <= err_cnt
+
+
+# Validation requirements for client adding and registration are at least currently identical.
+def validate_config_client_add_or_register(ss_config, operation, errors):
+    if not ss_config.get(ConfKeysSecurityServer.CONF_KEY_CLIENTS):
+        return True
+
+    err_cnt = len(errors)
+
+    if require_fill(ConfKeysSecurityServer.CONF_KEY_CLIENTS, ss_config, operation, errors):
+        for i in range(0, len(ss_config[ConfKeysSecurityServer.CONF_KEY_CLIENTS])):
+            # Pass on the security server context in 'server_name.client_config_id[x]
+            ss_config_client_slice = copy.deepcopy(ss_config[ConfKeysSecurityServer.CONF_KEY_CLIENTS][i])
+            ss_config_client_slice[ConfKeysSecurityServer.CONF_KEY_NAME] = (
+                ss_config[ConfKeysSecurityServer.CONF_KEY_NAME] + "." +
+                # Count indexes from 1 everywhere, as in key sanity reports of load_config()
+                ConfKeysSecurityServer.CONF_KEY_CLIENTS + '[' + str(i+1) + ']'
+            )
+
+            require_fill(
+                ConfKeysSecServerClients.CONF_KEY_SS_CLIENT_MEMBER_CLASS,
+                ss_config_client_slice, operation, errors
+            )
+
+            require_fill(
+                ConfKeysSecServerClients.CONF_KEY_SS_CLIENT_MEMBER_CODE,
+                ss_config_client_slice, operation, errors
+            )
+
+            require_fill(
+                ConfKeysSecServerClients.CONF_KEY_SS_CLIENT_SUBSYSTEM_CODE,
+                ss_config_client_slice, operation, errors
+            )
+
+            require_swagger_enum_fill(
+                ConnectionType,
+                ConfKeysSecServerClients.CONF_KEY_SS_CLIENT_CONNECTION_TYPE,
+                ss_config_client_slice, operation, errors
+            )
+
+    return len(errors) <= err_cnt
+
+
+def validate_config_service_desc_add_or_enable(ss_config, operation, errors):
+    if not ss_config.get(ConfKeysSecurityServer.CONF_KEY_CLIENTS):
+        return True
+
+    err_cnt = len(errors)
+
+    clients_config = copy.deepcopy(ss_config[ConfKeysSecurityServer.CONF_KEY_CLIENTS])
+    for client_ix in range(0, len(clients_config)):
+        if not clients_config[client_ix].get(ConfKeysSecServerClients.CONF_KEY_SS_CLIENT_SERVICE_DESCS):
+            continue
+
+        # Make readable reference
+        clients_config[client_ix][ConfKeysSecurityServer.CONF_KEY_NAME] = (
+            ss_config[ConfKeysSecurityServer.CONF_KEY_NAME] + "." +
+            ConfKeysSecurityServer.CONF_KEY_CLIENTS + '[' + str(client_ix + 1) + ']'
+        )
+
+        service_desc_config = copy.deepcopy(clients_config[client_ix][ConfKeysSecServerClients.CONF_KEY_SS_CLIENT_SERVICE_DESCS])
+        for service_desc_ix in range(0, len(service_desc_config)):
+            service_desc_config[service_desc_ix][ConfKeysSecurityServer.CONF_KEY_NAME] = (
+                    clients_config[client_ix][ConfKeysSecurityServer.CONF_KEY_NAME] + "." +
+                    ConfKeysSecServerClients.CONF_KEY_SS_CLIENT_SERVICE_DESCS + '[' + str(service_desc_ix + 1) + ']'
+            )
+
+            require_swagger_enum_fill(ServiceType,
+                                      ConfKeysSecServerClientServiceDesc.CONF_KEY_SS_CLIENT_SERVICE_DESC_TYPE,
+                                      service_desc_config[service_desc_ix], operation, errors)
+
+            require_fill(
+                ConfKeysSecServerClientServiceDesc.CONF_KEY_SS_CLIENT_SERVICE_DESC_URL,
+                service_desc_config[service_desc_ix], operation, errors)
+
+            if ServiceType.REST == service_desc_config[service_desc_ix].get(ConfKeysSecServerClientServiceDesc.CONF_KEY_SS_CLIENT_SERVICE_DESC_TYPE):
+                require_fill(
+                    ConfKeysSecServerClientServiceDesc.CONF_KEY_SS_CLIENT_SERVICE_DESC_REST_SERVICE_CODE,
+                    service_desc_config[service_desc_ix], operation, errors)
+
+    return len(errors) <= err_cnt

--- a/xrdsst/core/version.py
+++ b/xrdsst/core/version.py
@@ -1,7 +1,7 @@
 """Module for getting project version"""
 from cement.utils.version import get_version as cement_get_version
 
-CURRENT_VERSION = "0.2.2-alpha.0"
+CURRENT_VERSION = "0.2.3-alpha.0"
 
 
 def convert_version(version_str):

--- a/xrdsst/main.py
+++ b/xrdsst/main.py
@@ -1,14 +1,16 @@
 import logging
 import os
 import subprocess
+import sys
 import traceback
 
 import networkx
 import urllib3
 import yaml
+
 from cement import App, TestApp, init_defaults
 from cement.core.exc import CaughtSignal
-
+from typing import Callable
 from xrdsst.controllers.auto import AutoController
 from xrdsst.controllers.base import BaseController
 from xrdsst.controllers.cert import CertController
@@ -18,6 +20,10 @@ from xrdsst.controllers.status import StatusController
 from xrdsst.controllers.timestamp import TimestampController
 from xrdsst.controllers.init import InitServerController
 from xrdsst.controllers.token import TokenController
+from xrdsst.core.validator import validate_config_init, validate_config_timestamp_init, validate_config_token_login, \
+    validate_config_token_init_keys, validate_config_cert_import, validate_config_cert_register, \
+    validate_config_cert_activate, validate_config_client_add_or_register, validate_config_service_desc_add_or_enable
+from xrdsst.models import TokenInitStatus, TokenStatus, PossibleAction
 from xrdsst.resources.texts import texts
 
 META = init_defaults('output.json', 'output.tabulate')
@@ -28,13 +34,17 @@ META['output.tabulate']['overridable'] = True
 OP_GRAPH = networkx.DiGraph()
 OP_DEPENDENCY_LIST = []
 
-OP_INIT="INIT"
-OP_TOKEN_LOGIN="TOKEN\nLOGIN"
-OP_TIMESTAMP_ENABLE="TIMESTAMPING"
-OP_GENKEYS_CSRS="KEYS AND CSR\nGENERATION"
-OP_IMPORT_CERTS="CERTIFICATE\nIMPORT"
-OP_REGISTER_AUTH_CERT="REGISTER\nAUTH CERT"
-OP_ACTIVATE_AUTH_CERT="ACTIVATE\nAUTH CERT"
+OP_INIT = "INIT"
+OP_TOKEN_LOGIN = "TOKEN\nLOGIN"
+OP_TIMESTAMP_ENABLE = "TIMESTAMPING"
+OP_GENKEYS_CSRS = "KEYS AND CSR\nGENERATION"
+OP_IMPORT_CERTS = "CERTIFICATE\nIMPORT"
+OP_REGISTER_AUTH_CERT = "REGISTER\nAUTH CERT"
+OP_ACTIVATE_AUTH_CERT = "ACTIVATE\nAUTH CERT"
+OP_ADD_CLIENT = "ADD CLIENT"
+OP_REGISTER_CLIENT = "REGISTER CLIENT"
+OP_ADD_SERVICE_DESC = "ADD SERVICE\nDESCRIPTION"
+OP_ENABLE_SERVICE_DESC = "ENABLE SERVICE\nDESCRIPTION"
 
 
 # Operations supported and known at the dependency graph level
@@ -46,44 +56,114 @@ class OPS:
     IMPORT_CERTS = OP_IMPORT_CERTS
     REGISTER_AUTH_CERT = OP_REGISTER_AUTH_CERT
     ACTIVATE_AUTH_CERT = OP_ACTIVATE_AUTH_CERT
+    ADD_CLIENT = OP_ADD_CLIENT
+    REGISTER_CLIENT = OP_REGISTER_CLIENT
+    ADD_SERVICE_DESC = OP_ADD_SERVICE_DESC
+    ENABLE_SERVICE_DESC = OP_ENABLE_SERVICE_DESC
+
+
+VALIDATORS = {
+    OPS.INIT: validate_config_init,
+    OPS.TIMESTAMP_ENABLE: validate_config_timestamp_init,
+    OPS.TOKEN_LOGIN: validate_config_token_login,
+    OPS.GENKEYS_CSRS: validate_config_token_init_keys,
+    OPS.IMPORT_CERTS: validate_config_cert_import,
+    OPS.REGISTER_AUTH_CERT: validate_config_cert_register,
+    OPS.ACTIVATE_AUTH_CERT: validate_config_cert_activate,
+    OPS.ADD_CLIENT: validate_config_client_add_or_register,
+    OPS.REGISTER_CLIENT: validate_config_client_add_or_register,
+    OPS.ADD_SERVICE_DESC: validate_config_service_desc_add_or_enable,
+    OPS.ENABLE_SERVICE_DESC: validate_config_service_desc_add_or_enable
+}
 
 
 # Initialize operational dependency graph for the security server operations
 def opdep_init(app):
-    graph = OP_GRAPH
+    def add_op_node(g, op: str, controller, operation: Callable, **kwargs):
+        g.add_node(op, controller=controller, operation=operation, servers={}, **kwargs)
 
-    graph.add_node(OPS.ACTIVATE_AUTH_CERT,
-                   controller=CertController, operation=CertController.activate,
-                   configured=False)
-    graph.add_node(OPS.REGISTER_AUTH_CERT,
-                   controller=CertController, operation=CertController.register,
-                   configured=False)
-    graph.add_node(OPS.IMPORT_CERTS,
-                   controller=CertController, operation=CertController.import_,
-                   configured=False)
-    graph.add_node(OPS.GENKEYS_CSRS,
-                   controller=TokenController, operation=TokenController.init_keys,
-                   configured=False)
-    graph.add_node(OPS.TIMESTAMP_ENABLE,
-                   controller=TimestampController, operation=TimestampController.init,
-                   configured=False)
-    graph.add_node(OPS.INIT,
-                   controller=InitServerController, operation=InitServerController._default,
-                   configured=False)
-    graph.add_node(OPS.TOKEN_LOGIN,
-                   controller=TokenController, operation=TokenController.login,
-                   configured=False)
+    def is_done_initialization(ssn):
+        sins = OP_GRAPH.nodes[OPS.INIT]['servers'][ssn]['status'].server_init_status
 
-    graph.add_edge(OPS.REGISTER_AUTH_CERT, OPS.ACTIVATE_AUTH_CERT)
-    graph.add_edge(OPS.IMPORT_CERTS, OPS.REGISTER_AUTH_CERT)
-    graph.add_edge(OPS.INIT, OPS.TOKEN_LOGIN)
-    graph.add_edge(OPS.INIT, OPS.TIMESTAMP_ENABLE)
-    graph.add_edge(OPS.TOKEN_LOGIN, OPS.GENKEYS_CSRS)
-    graph.add_edge(OPS.GENKEYS_CSRS, OPS.IMPORT_CERTS)
+        return \
+            sins.has_anchor and sins.has_server_code and \
+            sins.has_server_owner and sins.token_init_status == TokenInitStatus.INITIALIZED
 
-    topologically_sorted = list(networkx.topological_sort(graph))
-    app.OP_GRAPH = graph
+    def is_done_tsa(ssn):
+        tsas = OP_GRAPH.nodes[OPS.TIMESTAMP_ENABLE]['servers'][ssn]['status'].timestamping_status
+        return tsas and len(tsas) > 0
+
+    def is_done_token_login(ssn):
+        tins = OP_GRAPH.nodes[OPS.TOKEN_LOGIN]['servers'][ssn]['status'].token_status
+        return tins.logged_in and TokenStatus.OK == tins.status
+
+    def is_done_token_keys_and_csrs(ssn):
+        sss = OP_GRAPH.nodes[OPS.GENKEYS_CSRS]['servers'][ssn]['status']
+
+        keys_done = (
+            (sss.status_keys.has_toolkit_sign_key and sss.status_keys.has_toolkit_auth_key) or
+            (sss.status_keys.has_sign_key and sss.status_keys.has_auth_key)
+        )
+
+        csrs_done = (
+            (sss.status_csrs.has_toolkit_sign_csr and sss.status_csrs.has_toolkit_auth_csr) or
+            (sss.status_certs.has_sign_cert and sss.status_certs.has_auth_cert)
+        )
+
+        return keys_done and csrs_done
+
+    def is_done_cert_import(ssn):
+        sss = OP_GRAPH.nodes[OPS.IMPORT_CERTS]['servers'][ssn]['status']
+        return sss.status_certs.has_sign_cert and sss.status_certs.has_auth_cert
+
+    def is_done_auth_cert_register(ssn):
+        sss = OP_GRAPH.nodes[OPS.REGISTER_AUTH_CERT]['servers'][ssn]['status']
+        return (
+            sss.status_certs.has_auth_cert and
+            sss.status_certs.auth_cert_actions and
+            PossibleAction.UNREGISTER in sss.status_certs.auth_cert_actions
+        )
+
+    def is_done_auth_cert_activate(ssn):
+        sss = OP_GRAPH.nodes[OPS.ACTIVATE_AUTH_CERT]['servers'][ssn]['status']
+        return (
+            sss.status_certs.has_auth_cert and
+            sss.status_certs.auth_cert_actions and
+            PossibleAction.DISABLE in sss.status_certs.auth_cert_actions
+        )
+
+    g = OP_GRAPH
+
+    add_op_node(g, OPS.ACTIVATE_AUTH_CERT, CertController, CertController.activate, is_done=is_done_auth_cert_activate)
+    add_op_node(g, OPS.REGISTER_AUTH_CERT, CertController, CertController.register, is_done=is_done_auth_cert_register)
+    add_op_node(g, OPS.IMPORT_CERTS, CertController, CertController.import_, is_done=is_done_cert_import)
+    add_op_node(g, OPS.GENKEYS_CSRS, TokenController, TokenController.init_keys, is_done=is_done_token_keys_and_csrs)
+    add_op_node(g, OPS.TIMESTAMP_ENABLE, TimestampController, TimestampController.init, is_done=is_done_tsa)
+    add_op_node(g, OPS.INIT, InitServerController, InitServerController._default, is_done=is_done_initialization)
+    add_op_node(g, OPS.TOKEN_LOGIN, TokenController, TokenController.login, is_done=is_done_token_login)
+    # End-user operations without binary /done/ criteria.
+    add_op_node(g, OPS.ADD_CLIENT, ClientController, ClientController.add, is_done=(lambda ssn: True))
+    add_op_node(g, OPS.REGISTER_CLIENT, ClientController, ClientController.register, is_done=(lambda ssn: True))
+    add_op_node(g, OPS.ADD_SERVICE_DESC, ServiceController, ServiceController.add_description, is_done=(lambda ssn: True))
+    add_op_node(g, OPS.ENABLE_SERVICE_DESC, ServiceController, ServiceController.enable_description, is_done=(lambda ssn: True))
+
+    g.add_edge(OPS.REGISTER_AUTH_CERT, OPS.ACTIVATE_AUTH_CERT)
+    g.add_edge(OPS.IMPORT_CERTS, OPS.REGISTER_AUTH_CERT)
+    g.add_edge(OPS.INIT, OPS.TOKEN_LOGIN)
+    g.add_edge(OPS.INIT, OPS.TIMESTAMP_ENABLE)
+    g.add_edge(OPS.TOKEN_LOGIN, OPS.GENKEYS_CSRS)
+    g.add_edge(OPS.GENKEYS_CSRS, OPS.IMPORT_CERTS)
+    g.add_edge(OPS.ACTIVATE_AUTH_CERT, OPS.ADD_CLIENT)
+    g.add_edge(OPS.ADD_CLIENT, OPS.REGISTER_CLIENT)
+    g.add_edge(OPS.ADD_CLIENT, OPS.ADD_SERVICE_DESC)
+    g.add_edge(OPS.ADD_SERVICE_DESC, OPS.ENABLE_SERVICE_DESC)
+
+    topologically_sorted = list(networkx.topological_sort(g))
+    app.OP_GRAPH = g
     app.OP_DEPENDENCY_LIST = topologically_sorted
+
+    # Do not presume autoconfig, activated on explicit invocation.
+    app.auto_apply = False
 
 
 def revoke_api_key(app):
@@ -91,28 +171,32 @@ def revoke_api_key(app):
         api_key_id = app.Meta.handlers[0].api_key_id
         if api_key_id:
             config_file = app.pargs.configfile if app.pargs.configfile else app.Meta.handlers[0].config_file
-            api_key_default = app.Meta.handlers[0].api_key_default
             if not os.path.exists(config_file):
                 config_file = os.path.join("..", config_file)
             with open(config_file, "r") as yml_file:
                 config = yaml.load(yml_file, Loader=yaml.FullLoader)
-            for security_server in config["security_server"]:
-                if security_server["api_key"] == api_key_default:
-                    log_info('Revoking API key for security server ' + security_server['name'])
-                    curl_cmd = "curl -X DELETE -u " + config["api_key"][0]["credentials"] + " --silent " + \
-                               config["api_key"][0]["url"] + "/" + str(api_key_id[security_server['name']]) + " -k"
-                    cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
-                        config["api_key"][0]["key"] + "\" root@" + security_server["name"] + " \"" + curl_cmd + "\""
-                    process = subprocess.run(cmd, shell=True, check=True, capture_output=True)
-                    if process.returncode == 0:
-                        log_info('API key for security server ' + security_server['name'] + ' revoked successfully')
-                    else:
-                        logging.error('Revoking of API key for security server ' + security_server['name'] + ' failed')
+            for ssn in api_key_id.keys():
+                logging.debug('Revoking API key for security server ' + ssn)
+                curl_cmd = "curl -X DELETE -u " + config["api_key"][0]["credentials"] + " --silent " + \
+                           config["api_key"][0]["url"] + "/" + str(api_key_id[ssn]) + " -k"
+                cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
+                    config["api_key"][0]["key"] + "\" root@" + ssn + " \"" + curl_cmd + "\""
+                process = subprocess.run(cmd, shell=True, check=True, capture_output=True)
+                api_key_token = app.api_keys[ssn].split('=')[1]
+                if process.returncode == 0:
+                    log_info("API key '" + api_key_token + "' for security server " + ssn + " revoked.")
+                else:
+                    logging.warning("Revocation of API key '" + api_key_token + "' for security server ' + ssn + ' failed")
 
 
 def log_info(message):
     logging.info(message)
     print(message)
+
+
+def less_verbose_urllib():
+    logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)  # If not true, then still the only way
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class XRDSST(App):
@@ -123,7 +207,8 @@ class XRDSST(App):
 
         hooks = [
             ('pre_setup', opdep_init),
-            ('pre_setup', lambda app: urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning))
+            ('pre_setup', lambda app: less_verbose_urllib()),
+            ('pre_close', revoke_api_key)
         ]
 
         # call sys.exit() on close
@@ -141,6 +226,8 @@ class XRDSST(App):
         handlers = [BaseController, StatusController, ClientController, CertController, TimestampController,
                     TokenController, InitServerController, AutoController, ServiceController]
 
+    api_keys = {}  # Keep key references for autoconfiguration and eventual revocation
+
 
 class XRDSSTTest(TestApp, XRDSST):
     """A sub-class of XRDSST that is better suited for testing."""
@@ -153,9 +240,18 @@ class XRDSSTTest(TestApp, XRDSST):
         handlers = XRDSST.Meta.handlers
 
 
+def main_excepthook(type_, value, traceback_):
+    if type_ == urllib3.exceptions.MaxRetryError:  # Retried traceback lengths otherwise multiple screens.
+        url = str(value.reason.pool._protocol) + "://" + str(value.pool.host) + ":" + str(value.pool.port) + value.url
+        message = "Could not connect to API endpoint " + url + ", retries exceeded."
+        print(message, file=sys.stderr)
+    else:
+        sys.__excepthook__(type_, value, traceback_)
+
 def main():
+    sys.excepthook = main_excepthook
+
     with XRDSST() as app:
-        app.hook.register('pre_close', revoke_api_key)
         try:
             app.run()
         except AssertionError as err:

--- a/xrdsst/resources/texts.py
+++ b/xrdsst/resources/texts.py
@@ -1,6 +1,9 @@
 texts = {
+    # App
     'app.description': 'A toolkit for configuring security server',
     'app.label': 'xrdsst',
+
+    # Controllers
     'auto.controller.description': 'Automatically performs all operations possible with configuration.',
     'cert.controller.description': 'Commands for performing certificate operations.',
     'client.controller.description': 'Commands for performing client management operations.',
@@ -8,5 +11,12 @@ texts = {
     'timestamp.controller.description': 'Commands for performing timestamping service operations.',
     'token.controller.description': 'Commands for performing token operations.',
     'service.controller.description': 'Commands for performing service operations.',
-    'status.controller.description': 'Query for server configuration statuses.'
+    'status.controller.description': 'Query for server configuration statuses.',
+
+    # Messages
+    'message.file.not.found': "File '{}' not found.",
+    'message.file.unreadable': "Could not read file '{}'.",
+    'message.config.unparsable': "Error parsing config: {}",
+    'message.config.serverless': "No security servers defined in '{}'.",
+    'message.skipped': "SKIPPED '{}'"
 }


### PR DESCRIPTION
SUMMARY
-------

Server state handling:
  * server states are carried and propagated in the operation graph for all nodes ('servers' entry), per security server
```
      NODE = {
        'servers' : {
           server_name : {
             'api_config' : Configuration,
             'status' : ServerStatus
           } 
        },
        'is_done' : Function
        /* previously existing */
        'controller' : Class,
        'operation' : Function
      }
```


Error handling:
  * Configuration:
     * two-staged:
         1) immediate errors and configuration key errors are reported immediately
         2) configuration value errors & runtime errors are reported at the time
            of operation execution
     * unexisting file / unreadable file
       - error message / same + with OS errno translation (IOError)) & exit
     * malformed YAML
       - parser level error message, block start to block end, in case of minor
         errors block end is usually better place to start the fixes & exit
     * invalid configuration keys
       - error message with invalid key, list of valid keys for section & exit
     * missing security server definition
       - error message & exit
     * missing 'name' or 'url' for security server
       - error message pinpointing security server YAML index (1-base) & exit
     * non-unique 'name' or 'url' among security servers
       - error message pinpointing security server YAML index, relevant key & exit
     * operation-specific configuration errors
       - error message about missing configuration key required for the operation
       - error messages for values determined to be invalid (file references, swagger enums)
     * temporary API key creation will be attempted whenever configured token is not UUID
    
Autoconfiguration & single operations:
  * server connectivity errors
    - error message (SKIPPED ... + errno translation)

Autoconfiguration:
  * client and service description operations added to operation graph
```
┌─────────────────┐     ┌────────────────┐
│  TIMESTAMPING   │ ◀── │      INIT      │
└─────────────────┘     └────────────────┘
                          │
                          │
                          ▼
                        ┌────────────────┐
                        │     TOKEN      │
                        │     LOGIN      │
                        └────────────────┘
                          │
                          │
                          ▼
                        ┌────────────────┐
                        │  KEYS AND CSR  │
                        │   GENERATION   │
                        └────────────────┘
                          │
                          │
                          ▼
                        ┌────────────────┐
                        │  CERTIFICATE   │
                        │     IMPORT     │
                        └────────────────┘
                          │
                          │
                          ▼
                        ┌────────────────┐
                        │    REGISTER    │
                        │   AUTH CERT    │
                        └────────────────┘
                          │
                          │
                          ▼
                        ┌────────────────┐
                        │    ACTIVATE    │
                        │   AUTH CERT    │
                        └────────────────┘
                          │
                          │
                          ▼
┌─────────────────┐     ┌────────────────┐
│ REGISTER CLIENT │ ◀── │   ADD CLIENT   │
└─────────────────┘     └────────────────┘
                          │
                          │
                          ▼
                        ┌────────────────┐
                        │  ADD SERVICE   │
                        │  DESCRIPTION   │
                        └────────────────┘
                          │
                          │
                          ▼
                        ┌────────────────┐
                        │ ENABLE SERVICE │
                        │  DESCRIPTION   │
                        └────────────────┘


```


  * ``cert download-csrs`` is NOT part of operation graph
  * controllers' ``is_autoconfig()`` returns True when running in autoconfiguration mode
  * dependent operations now performed for each security server in succession, not in succession for all security servers separately
  * if API creation needed, it is created once per security server, not once per security server operation
  * base status operations of security server, that are repeated with autoconfig, are marked as '(redo)'
  * general configuration changes that have no completion criteria are marked as '(redo)'
  * when completion of one step is not completed, further operations on same security server not attempted
  * for each security server, base status operations table is output at the end of either complete or incomplete autoconfiguration run


Single operations:
  * operational requirements not met
     - error message (SKIPPED .. + required operations listed)
     
Informational messages:
  * less clutter, many verbose INFO level logs changed to DEBUG level

Other notes:
  * There are now constants for all used configuration keys in ConfKeys* -- these are used in new code or old
    code that was touched, refactor to use them exclusively is better done separately to not clutter the
    functional changes.
