### PR TITLE
End to end tests

### DIFF
--- a/reset_security_server.sh
+++ b/reset_security_server.sh
@@ -61,18 +61,23 @@ run_ansible_script() {
 }
 
 add_public_key() {
+    ssh_user=$2
+    ssh_key=$3
+    ssh_folder_name=$4
+    auth_keys_file_name=$5
+
     names=$(echo "$1" | tr "," "\n")
     for name in $names
     do
-        printf "\nAdding public key to LXD container %s\n" "$name"
-        lxc exec "$name" -- bash -c "useradd -c \"$2 user\" -d /home/$2 -s /bin/bash $2"
-        lxc exec "$name" -- bash -c "echo \"$2 ALL=(ALL) NOPASSWD: ALL\" > /etc/sudoers.d/$2"
-        lxc exec "$name" -- bash -c "mkdir -p /home/$2/$4"
-        lxc exec "$name" -- bash -c "echo \"$(cat "$3")\" > /home/$2/$4/$5"
-        lxc exec "$name" -- bash -c "chown -R $2:$2 /home/$2"
-        lxc exec "$name" -- bash -c "chmod 0700 /home/$2"
-        lxc exec "$name" -- bash -c "chmod 0700 /home/$2/$4"
-        lxc exec "$name" -- bash -c "chmod 0600 /home/$2/$4/$5"
+        printf "\nAdding public key to LXD container \"%s\" for user \"%s\"\n with SSH key \"%s\"\n" "$name" "$ssh_user" "$ssh_key"
+        lxc exec "$name" -- bash -c "useradd -c \"$ssh_user user\" -d /home/$ssh_user -s /bin/bash $ssh_user"
+        lxc exec "$name" -- bash -c "echo \"$ssh_user ALL=(ALL) NOPASSWD: ALL\" > /etc/sudoers.d/$ssh_user"
+        lxc exec "$name" -- bash -c "mkdir -p /home/$ssh_user/$ssh_folder_name"
+        lxc exec "$name" -- bash -c "echo \"$(cat "$ssh_key")\" > /home/$ssh_user/$ssh_folder_name/$auth_keys_file_name"
+        lxc exec "$name" -- bash -c "chown -R $ssh_user:$ssh_user /home/$ssh_user"
+        lxc exec "$name" -- bash -c "chmod 0700 /home/$ssh_user"
+        lxc exec "$name" -- bash -c "chmod 0700 /home/$ssh_user/$ssh_folder_name"
+        lxc exec "$name" -- bash -c "chmod 0600 /home/$ssh_user/$ssh_folder_name/$auth_keys_file_name"
     done
 }
 

--- a/reset_security_server.sh
+++ b/reset_security_server.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
-# Usage reset_security_server.sh -n server(s) -h path/to/hosts.txt -a path/to/ansible -k path/to/public_key_file
+# Usage reset_security_server.sh -n server(s) -h path/to/hosts.txt -a path/to/ansible -u ssh_user -k path/to/public_key_file
 #
 # Description of required command line arguments:
 #
 #   -n: name(s) of security servers to be re-initialized (has to conform with the ones listed in hosts file)
 #   -h: lxd hosts file, this file is used by the Ansible script to install security servers
 #   -a: path to ansible script, this is the path to where the Ansible script is located in the locally cloned X-Road Git repository
+#   -u: ssh user name
 #   -k: path to public ssh key file
 #
 #   The LXD hosts file and the Ansible script file that should be used by this script can be found here:
 #   https://github.com/nordic-institute/X-Road/blob/develop/ansible
 #
-# Usage example: reset_security_server.sh -n ss3,ss4 -h ../X-Road/ansible/hosts/lxd_hosts.txt -a ../X-Road/ansible -k public_key_file
+# Usage example: reset_security_server.sh -n ss3,ss4 -h ../X-Road/ansible/hosts/lxd_hosts.txt -a ../X-Road/ansible -u ssh_user -k public_key_file
 
 ANSIBLE_CMD="ansible-playbook"
 ANSIBLE_SCRIPT="xroad_init.yml"
@@ -19,7 +20,7 @@ SSH_FOLDER=".ssh"
 AUTHORIZED_KEYS_FILE="authorized_keys"
 
 usage() {
-  echo "Usage: reset_security_server.sh -n name(s) -h hosts.txt -a ansible_folder -k public_key_file"
+  echo "Usage: reset_security_server.sh -n name(s) -h hosts.txt -a ansible_folder -u ssh_user -k public_key_file"
 }
 
 exit_abnormal() {
@@ -64,12 +65,18 @@ add_public_key() {
     for name in $names
     do
         printf "\nAdding public key to LXD container %s\n" "$name"
-        lxc exec "$name" -- bash -c "mkdir -p $3"
-        lxc exec "$name" -- bash -c "echo \"$(cat "$2")\" > $3/$4"
+        lxc exec "$name" -- bash -c "useradd -c \"$2 user\" -d /home/$2 -s /bin/bash $2"
+        lxc exec "$name" -- bash -c "echo \"$2 ALL=(ALL) NOPASSWD: ALL\" > /etc/sudoers.d/$2"
+        lxc exec "$name" -- bash -c "mkdir -p /home/$2/$4"
+        lxc exec "$name" -- bash -c "echo \"$(cat "$3")\" > /home/$2/$4/$5"
+        lxc exec "$name" -- bash -c "chown -R $2:$2 /home/$2"
+        lxc exec "$name" -- bash -c "chmod 0700 /home/$2"
+        lxc exec "$name" -- bash -c "chmod 0700 /home/$2/$4"
+        lxc exec "$name" -- bash -c "chmod 0600 /home/$2/$4/$5"
     done
 }
 
-while getopts ":n:h:a:k:" options; do
+while getopts ":n:h:a:u:k:" options; do
   case "${options}" in
     n )
       NAME=${OPTARG}
@@ -79,6 +86,9 @@ while getopts ":n:h:a:k:" options; do
       ;;
     a )
       ANSIBLE=${OPTARG}
+      ;;
+    u )
+      USER=${OPTARG}
       ;;
     k )
       KEY=${OPTARG}
@@ -90,13 +100,13 @@ while getopts ":n:h:a:k:" options; do
 done
 
 
-if [[ $NAME == "" ]] | [[ $HOSTS == "" ]] | [[ $ANSIBLE == "" ]] | [[ $KEY == "" ]]; then
+if [[ $NAME == "" ]] | [[ $HOSTS == "" ]] | [[ $ANSIBLE == "" ]] | [[ $USER == "" ]] | [[ $KEY == "" ]]; then
     exit_abnormal
 fi
 
 delete_containers "$NAME"
 run_ansible_script "$ANSIBLE" "$ANSIBLE_CMD" "$HOSTS" "$ANSIBLE_SCRIPT"
-add_public_key "$NAME" "$KEY" "$SSH_FOLDER" "$AUTHORIZED_KEYS_FILE"
+add_public_key "$NAME" "$USER" "$KEY" "$SSH_FOLDER" "$AUTHORIZED_KEYS_FILE"
 
 
 

--- a/tests/end_to_end/tests.py
+++ b/tests/end_to_end/tests.py
@@ -230,7 +230,6 @@ class EndToEndTest(unittest.TestCase):
         assert description["services"][0]["timeout"] == 120
         assert description["services"][0]["url"] == 'http://petstore.xxx'
 
-
     def step_autoconf(self):
         with XRDSSTTest() as app:
             with mock.patch.object(BaseController, 'load_config',  (lambda x, y=None: self.config)):

--- a/tests/end_to_end/tests.py
+++ b/tests/end_to_end/tests.py
@@ -41,7 +41,7 @@ class EndToEndTest(unittest.TestCase):
                 self.create_api_key(api_key)
 
     def tearDown(self):
-        #self.revoke_api_key()
+        self.revoke_api_key()
         if self.config_file is not None:
             if os.path.exists(self.config_file):
                 os.remove(self.config_file)

--- a/tests/end_to_end/tests.py
+++ b/tests/end_to_end/tests.py
@@ -141,8 +141,7 @@ class EndToEndTest(unittest.TestCase):
                    self.config["api_key"][0]["url"] + "/" + str(base.api_key_id[self.config["security_server"][0]['name']]) + " -k"
         cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
               self.config["api_key"][0]["key"] + "\" root@" + self.config["security_server"][0]["name"] + " \"" + curl_cmd + "\""
-        #subprocess.run(cmd, shell=True, check=False, capture_output=True)
-        subprocess.check_output(cmd, shell=True)
+        subprocess.run(cmd, shell=True, check=False, capture_output=True)
 
     def step_cert_import(self):
         with XRDSSTTest() as app:

--- a/tests/end_to_end/tests.py
+++ b/tests/end_to_end/tests.py
@@ -41,7 +41,7 @@ class EndToEndTest(unittest.TestCase):
                 self.create_api_key(api_key)
 
     def tearDown(self):
-        self.revoke_api_key()
+        #self.revoke_api_key()
         if self.config_file is not None:
             if os.path.exists(self.config_file):
                 os.remove(self.config_file)

--- a/tests/end_to_end/tests.py
+++ b/tests/end_to_end/tests.py
@@ -140,8 +140,8 @@ class EndToEndTest(unittest.TestCase):
         curl_cmd = "curl -X DELETE -u " + self.config["api_key"][0]["credentials"] + " --silent " + \
                    self.config["api_key"][0]["url"] + "/" + str(base.api_key_id[self.config["security_server"][0]['name']]) + " -k"
         cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
-              self.config["api_key"][0]["key"] + "\" root@" + self.config["security_server"][0]["name"] + " \"" + curl_cmd + "\""
-        subprocess.run(cmd, shell=True, check=False, capture_output=True)
+              self.config["api_key"][0]["key"] + "\" niis@" + self.config["security_server"][0]["name"] + " \"" + curl_cmd + "\""
+        subprocess.getoutput(cmd)
 
     def step_cert_import(self):
         with XRDSSTTest() as app:

--- a/tests/end_to_end/tests.py
+++ b/tests/end_to_end/tests.py
@@ -141,7 +141,8 @@ class EndToEndTest(unittest.TestCase):
                    self.config["api_key"][0]["url"] + "/" + str(base.api_key_id[self.config["security_server"][0]['name']]) + " -k"
         cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
               self.config["api_key"][0]["key"] + "\" root@" + self.config["security_server"][0]["name"] + " \"" + curl_cmd + "\""
-        subprocess.run(cmd, shell=True, check=False, capture_output=True)
+        #subprocess.run(cmd, shell=True, check=False, capture_output=True)
+        subprocess.check_output(cmd, shell=True)
 
     def step_cert_import(self):
         with XRDSSTTest() as app:

--- a/tests/end_to_end/tests.py
+++ b/tests/end_to_end/tests.py
@@ -141,7 +141,9 @@ class EndToEndTest(unittest.TestCase):
                    self.config["api_key"][0]["url"] + "/" + str(base.api_key_id[self.config["security_server"][0]['name']]) + " -k"
         cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
               self.config["api_key"][0]["key"] + "\" niis@" + self.config["security_server"][0]["name"] + " \"" + curl_cmd + "\""
-        subprocess.getoutput(cmd)
+        exitcode, data = subprocess.getstatusoutput(cmd)
+        if exitcode != 0:
+            self.log_api_error('API key revoking for security server ' + self.config["security_server"][0]['name'] + ' failed.')
 
     def step_cert_import(self):
         with XRDSSTTest() as app:

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -67,10 +67,13 @@ class BaseController(Controller):
                    " --header \'Content-Type: application/json\' -k"
         cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
               config["api_key"][0]["key"] + "\" niis@" + security_server["name"] + " \"" + curl_cmd + "\""
+        self.log_info("cmd: " + cmd)
         if os.path.isfile(config["api_key"][0]["key"]):
             try:
                 process = subprocess.getoutput(cmd)
+                self.log_info("PROCESS: " + str(process))
                 api_key_json = json.loads(process)
+                self.log_info("api_key: " + str(api_key_json))
                 self.api_key_id[security_server['name']] = api_key_json["id"]
                 self.log_info('API key \"' + api_key_json["key"] + '\" for security server ' + security_server['name'] +
                               ' created.')

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -73,6 +73,7 @@ class BaseController(Controller):
                 #api_key_json = json.loads(str(process.stdout, 'utf-8').strip())
                 #process = subprocess.check_output(cmd, shell=True)
                 process = subprocess.getoutput(cmd)
+                self.log_info("PROCESS: " + str(process))
                 api_key_json = json.loads(process)
                 self.api_key_id[security_server['name']] = api_key_json["id"]
                 self.log_info('API key \"' + api_key_json["key"] + '\" for security server ' + security_server['name'] +

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -69,12 +69,8 @@ class BaseController(Controller):
               config["api_key"][0]["key"] + "\" root@" + security_server["name"] + " \"" + curl_cmd + "\""
         if os.path.isfile(config["api_key"][0]["key"]):
             try:
-                #process = subprocess.run(cmd, shell=True, check=False, capture_output=True)
-                #api_key_json = json.loads(str(process.stdout, 'utf-8').strip())
-                process = subprocess.check_output(cmd, shell=True)
-                self.log_info("PROCESS=" + str(process))
-                api_key_json = json.loads(str(process, 'utf-8').strip())
-                self.log_info("API_KEY_JSON=" + str(api_key_json))
+                process = subprocess.run(cmd, shell=True, check=False, capture_output=True)
+                api_key_json = json.loads(str(process.stdout, 'utf-8').strip())
                 self.api_key_id[security_server['name']] = api_key_json["id"]
                 self.log_info('API key \"' + api_key_json["key"] + '\" for security server ' + security_server['name'] +
                               ' created.')

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -72,7 +72,9 @@ class BaseController(Controller):
                 #process = subprocess.run(cmd, shell=True, check=False, capture_output=True)
                 #api_key_json = json.loads(str(process.stdout, 'utf-8').strip())
                 process = subprocess.check_output(cmd, shell=True)
+                self.log_info("PROCESS=" + str(process))
                 api_key_json = json.loads(str(process, 'utf-8').strip())
+                self.log_info("API_KEY_JSON=" + str(api_key_json))
                 self.api_key_id[security_server['name']] = api_key_json["id"]
                 self.log_info('API key \"' + api_key_json["key"] + '\" for security server ' + security_server['name'] +
                               ' created.')

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -66,14 +66,10 @@ class BaseController(Controller):
                    config["api_key"][0]["url"] + " --data \'" + json.dumps(roles).replace('"', '\\"') + "\'" + \
                    " --header \'Content-Type: application/json\' -k"
         cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
-              config["api_key"][0]["key"] + "\" root@" + security_server["name"] + " \"" + curl_cmd + "\""
+              config["api_key"][0]["key"] + "\" niis@" + security_server["name"] + " \"" + curl_cmd + "\""
         if os.path.isfile(config["api_key"][0]["key"]):
             try:
-                #process = subprocess.run(cmd, shell=True, check=False, capture_output=True)
-                #api_key_json = json.loads(str(process.stdout, 'utf-8').strip())
-                #process = subprocess.check_output(cmd, shell=True)
                 process = subprocess.getoutput(cmd)
-                self.log_info("PROCESS: " + str(process))
                 api_key_json = json.loads(process)
                 self.api_key_id[security_server['name']] = api_key_json["id"]
                 self.log_info('API key \"' + api_key_json["key"] + '\" for security server ' + security_server['name'] +

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -69,8 +69,10 @@ class BaseController(Controller):
               config["api_key"][0]["key"] + "\" root@" + security_server["name"] + " \"" + curl_cmd + "\""
         if os.path.isfile(config["api_key"][0]["key"]):
             try:
-                process = subprocess.run(cmd, shell=True, check=False, capture_output=True)
-                api_key_json = json.loads(str(process.stdout, 'utf-8').strip())
+                #process = subprocess.run(cmd, shell=True, check=False, capture_output=True)
+                #api_key_json = json.loads(str(process.stdout, 'utf-8').strip())
+                process = subprocess.check_output(cmd, shell=True)
+                api_key_json = json.loads(str(process, 'utf-8').strip())
                 self.api_key_id[security_server['name']] = api_key_json["id"]
                 self.log_info('API key \"' + api_key_json["key"] + '\" for security server ' + security_server['name'] +
                               ' created.')

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -69,12 +69,15 @@ class BaseController(Controller):
               config["api_key"][0]["key"] + "\" niis@" + security_server["name"] + " \"" + curl_cmd + "\""
         if os.path.isfile(config["api_key"][0]["key"]):
             try:
-                process = subprocess.getoutput(cmd)
-                api_key_json = json.loads(process)
-                self.api_key_id[security_server['name']] = api_key_json["id"]
-                self.log_info('API key \"' + api_key_json["key"] + '\" for security server ' + security_server['name'] +
-                              ' created.')
-                return api_key_json["key"]
+                exitcode, data = subprocess.getstatusoutput(cmd)
+                if exitcode == 0:
+                    api_key_json = json.loads(data)
+                    self.api_key_id[security_server['name']] = api_key_json["id"]
+                    self.log_info('API key \"' + api_key_json["key"] + '\" for security server ' + security_server['name'] +
+                                  ' created.')
+                    return api_key_json["key"]
+                else:
+                    self.log_api_error('API key creation for security server ' + security_server['name'] + ' failed.')
             except Exception as err:
                 self.log_api_error('BaseController->create_api_key:', err)
         else:

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -67,13 +67,10 @@ class BaseController(Controller):
                    " --header \'Content-Type: application/json\' -k"
         cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
               config["api_key"][0]["key"] + "\" niis@" + security_server["name"] + " \"" + curl_cmd + "\""
-        self.log_info("cmd: " + cmd)
         if os.path.isfile(config["api_key"][0]["key"]):
             try:
                 process = subprocess.getoutput(cmd)
-                self.log_info("PROCESS: " + str(process))
                 api_key_json = json.loads(process)
-                self.log_info("api_key: " + str(api_key_json))
                 self.api_key_id[security_server['name']] = api_key_json["id"]
                 self.log_info('API key \"' + api_key_json["key"] + '\" for security server ' + security_server['name'] +
                               ' created.')

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -71,10 +71,9 @@ class BaseController(Controller):
             try:
                 #process = subprocess.run(cmd, shell=True, check=False, capture_output=True)
                 #api_key_json = json.loads(str(process.stdout, 'utf-8').strip())
-                process = subprocess.check_output(cmd, shell=True)
-                self.log_info("PROCESS=" + str(process))
-                api_key_json = json.loads(str(process, 'utf-8').strip())
-                self.log_info("API_KEY_JSON=" + str(api_key_json))
+                #process = subprocess.check_output(cmd, shell=True)
+                process = subprocess.getoutput(cmd)
+                api_key_json = json.loads(process)
                 self.api_key_id[security_server['name']] = api_key_json["id"]
                 self.log_info('API key \"' + api_key_json["key"] + '\" for security server ' + security_server['name'] +
                               ' created.')

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -69,8 +69,12 @@ class BaseController(Controller):
               config["api_key"][0]["key"] + "\" root@" + security_server["name"] + " \"" + curl_cmd + "\""
         if os.path.isfile(config["api_key"][0]["key"]):
             try:
-                process = subprocess.run(cmd, shell=True, check=False, capture_output=True)
-                api_key_json = json.loads(str(process.stdout, 'utf-8').strip())
+                #process = subprocess.run(cmd, shell=True, check=False, capture_output=True)
+                #api_key_json = json.loads(str(process.stdout, 'utf-8').strip())
+                process = subprocess.check_output(cmd, shell=True)
+                self.log_info("PROCESS=" + str(process))
+                api_key_json = json.loads(str(process, 'utf-8').strip())
+                self.log_info("API_KEY_JSON=" + str(api_key_json))
                 self.api_key_id[security_server['name']] = api_key_json["id"]
                 self.log_info('API key \"' + api_key_json["key"] + '\" for security server ' + security_server['name'] +
                               ' created.')

--- a/xrdsst/main.py
+++ b/xrdsst/main.py
@@ -190,7 +190,7 @@ def revoke_api_key(app):
                 curl_cmd = "curl -X DELETE -u " + config["api_key"][0]["credentials"] + " --silent " + \
                            config["api_key"][0]["url"] + "/" + str(api_key_id[ssn]) + " -k"
                 cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
-                      config["api_key"][0]["key"] + "\" root@" + ssn + " \"" + curl_cmd + "\""
+                      config["api_key"][0]["key"] + "\" niis@" + ssn + " \"" + curl_cmd + "\""
                 exitcode, data = subprocess.getstatusoutput(cmd)
                 api_key_token = app.api_keys[ssn].split('=')[1]
                 if exitcode == 0:

--- a/xrdsst/main.py
+++ b/xrdsst/main.py
@@ -191,9 +191,9 @@ def revoke_api_key(app):
                            config["api_key"][0]["url"] + "/" + str(api_key_id[ssn]) + " -k"
                 cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
                       config["api_key"][0]["key"] + "\" root@" + ssn + " \"" + curl_cmd + "\""
-                process = subprocess.run(cmd, shell=True, check=True, capture_output=True)
+                exitcode, data = subprocess.getstatusoutput(cmd)
                 api_key_token = app.api_keys[ssn].split('=')[1]
-                if process.returncode == 0:
+                if exitcode == 0:
                     log_info("API key '" + api_key_token + "' for security server " + ssn + " revoked.")
                 else:
                     logging.warning("Revocation of API key '" + api_key_token + "' for security server ' + ssn + ' failed")


### PR DESCRIPTION
A minor fix to subprocess usage related to api keys, namely substituting subprocess.run with subprocess.getoutput to make it compatible with Python 3.6+. In addition, "root" key has been changed to "niis" where SSH access to security server is performed and "reset_security_servers" script has been amended to also take ssh user as parameter, currently "niis" should be given ti make it compatible with the source code, but in an upcoming user story the SSH user will be made configurable from the YAML.