### PR TITLE
SSTOOLKIT-56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.2-alpha.0] - 2021-03-29
+- Make SSH user configurable for api key creation
+
 ## [0.3.1-alpha.0] - 2021-03-26
 - Add the external FQDN specification support for certificates and service providers.
 

--- a/config/xrdsst.yml
+++ b/config/xrdsst.yml
@@ -1,5 +1,5 @@
+admin_credentials: <SECURITY_SERVER_CREDENTIALS>
 ssh_access:
-  admin_credentials: <SECURITY_SERVER_CREDENTIALS>
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
 security_server:

--- a/config/xrdsst.yml
+++ b/config/xrdsst.yml
@@ -1,14 +1,14 @@
 admin_credentials: <SECURITY_SERVER_CREDENTIALS>
+api_key_roles:
+- XROAD_SYSTEM_ADMINISTRATOR
+- XROAD_SERVICE_ADMINISTRATOR
+- XROAD_SECURITY_OFFICER
+- XROAD_REGISTRATION_OFFICER
 ssh_access:
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
 security_server:
 - api_key: X-Road-apikey token=<API_KEY>
-  api_key_roles:
-  - XROAD_SYSTEM_ADMINISTRATOR
-  - XROAD_SERVICE_ADMINISTRATOR
-  - XROAD_SECURITY_OFFICER
-  - XROAD_REGISTRATION_OFFICER
   api_key_url: https://localhost:4000/api/v1/api-keys
   admin_credentials:
   configuration_anchor: /path/to/configuration-anchor.xml

--- a/config/xrdsst.yml
+++ b/config/xrdsst.yml
@@ -5,7 +5,10 @@ ssh_access:
 security_server:
 - api_key: X-Road-apikey token=<API_KEY>
   api_key_roles:
-    - <SECURITY_SERVER_ROLE_NAME>
+  - XROAD_SYSTEM_ADMINISTRATOR
+  - XROAD_SERVICE_ADMINISTRATOR
+  - XROAD_SECURITY_OFFICER
+  - XROAD_REGISTRATION_OFFICER
   api_key_url: https://localhost:4000/api/v1/api-keys
   admin_credentials:
   configuration_anchor: /path/to/configuration-anchor.xml

--- a/config/xrdsst.yml
+++ b/config/xrdsst.yml
@@ -1,5 +1,5 @@
 ssh_access:
-  admin_credentials: <SECURITTY_SERVER_CREDENTIALS>
+  admin_credentials: <SECURITY_SERVER_CREDENTIALS>
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
 security_server:

--- a/config/xrdsst.yml
+++ b/config/xrdsst.yml
@@ -1,12 +1,13 @@
-security_server:
-- api_key:
-  - key: X-Road-apikey token=<API_KEY>
-    credentials: <SECURITTY_SERVER_CREDENTIALS>
-    ssh_user: <SSH_USER>
-    ssh_key: /path/to/ssh_private_key
-    roles:
+ssh_access:
+  admin_credentials: <SECURITTY_SERVER_CREDENTIALS>
+  user: <SSH_USER>
+  private_key: /path/to/ssh_private_key
+security-server:
+- api_key: X-Road-apikey token=<API_KEY>
+  api_key_roles:
     - <SECURITY_SERVER_ROLE_NAME>
-    url: https://localhost:4000/api/v1/api-keys
+  api_key_url: https://localhost:4000/api/v1/api-keys
+  admin_credentials:
   configuration_anchor: /path/to/configuration-anchor.xml
   certificates:
     - /path/to/signcert
@@ -21,6 +22,8 @@ security_server:
   software_token_pin: <SOFT_TOKEN_PIN>
   fqdn: <SECURITY_SERVER_EXTERNAL_FQDN>
   url: https://<SECURITY_SERVER_INTERNAL_FQDN_OR_IP>:4000/api/v1
+  ssh_user: <SSH_USER>
+  ssh_private_key: /path/to/ssh_private_key
   clients:
     - member_class: <MEMBER_CLASS>
       member_code: <MEMBER_CODE>

--- a/config/xrdsst.yml
+++ b/config/xrdsst.yml
@@ -2,7 +2,7 @@ ssh_access:
   admin_credentials: <SECURITTY_SERVER_CREDENTIALS>
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
-security-server:
+security_server:
 - api_key: X-Road-apikey token=<API_KEY>
   api_key_roles:
     - <SECURITY_SERVER_ROLE_NAME>

--- a/config/xrdsst.yml
+++ b/config/xrdsst.yml
@@ -1,15 +1,16 @@
-api_key:
-- credentials: xrd:secret
-  key: /path/to/ssh_private_key
-  roles:
-  - <SECURITY_SERVER_ROLE_NAME>
-  url: https://localhost:4000/api/v1/api-keys
 security_server:
-- api_key: X-Road-apikey token=<API_KEY>
+- api_key:
+  - key: X-Road-apikey token=<API_KEY>
+    credentials: <SECURITTY_SERVER_CREDENTIALS>
+    ssh_user: <SSH_USER>
+    ssh_key: /path/to/ssh_private_key
+    roles:
+    - <SECURITY_SERVER_ROLE_NAME>
+    url: https://localhost:4000/api/v1/api-keys
+  configuration_anchor: /path/to/configuration-anchor.xml
   certificates:
     - /path/to/signcert
     - /path/to/authcert
-  configuration_anchor: /path/to/configuration-anchor.xml
   name: <SECURITY_SERVER_NAME>
   owner_dn_country: <OWNER_DISTINGUISHED_NAME_COUNTRY>
   owner_dn_org: <OWNER_DISTINGUISHED_NAME_ORGANIZATION>

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -110,14 +110,15 @@ $ pip install setup.py
   
 ### 3.2 Format of configuration file
 ```
-api-key:
-- credentials: <SECURITTY_SERVER_CREDENTIALS>
-  key: /path/to/ssh_private_key
-  roles:
-  - <SECURITY_SERVER_ROLE_NAME>
-  url: https://localhost:4000/api/v1/api-keys
 security-server:
-- api_key: X-Road-apikey token=<API_KEY>
+- api_key:
+  - key: X-Road-apikey token=<API_KEY>
+    credentials: <SECURITTY_SERVER_CREDENTIALS>
+    ssh_user: <SSH_USER>
+    ssh_key: /path/to/ssh_private_key
+    roles:
+    - <SECURITY_SERVER_ROLE_NAME>
+    url: https://localhost:4000/api/v1/api-keys
   configuration_anchor: /path/to/configuration-anchor.xml
   certificates:
     - /path/to/signcert
@@ -160,6 +161,7 @@ The ``logging`` section is for configuring the logging parameters of the X-Road 
 The ``security-server`` section is for configuring security server parameters
 
 * <SECURITY_SERVER_CREDENTIALS> X-Road Security Server credentials, e.g. xrd:secret
+* <SSH_USER> SSH username
 * ``/path/to/ssh_private_key`` should be substituted with the correct path to the ssh private key file, e.g. home/user/id_rsa
 * <SECURITY_SERVER_ROLE_NAME> parameter required for security server api key, should be substituted with a security server role name, e.g. XROAD_SYSTEM_ADMINISTRATOR    
 * ``/path/to/xrdsst.log`` should be substituted with the correct path to the log file, e.g. "/var/log/xroad/xrdsst.log"

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -111,9 +111,10 @@ $ pip install setup.py
 ### 3.2 Format of configuration file
 ```
 ssh_access:
+  admin_credentials: <SECURITTY_SERVER_CREDENTIALS>
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
-security-server:
+security_server:
 - api_key: X-Road-apikey token=<API_KEY>
   api_key_roles:
     - <SECURITY_SERVER_ROLE_NAME>
@@ -158,9 +159,8 @@ security-server:
               url: <SERVICE_URL>
 ```
 
-The ``api-key`` section is for configuring the automatic api key generation parameters for security server
-The ``logging`` section is for configuring the logging parameters of the X-Road Security Server Toolkit
-The ``security-server`` section is for configuring security server parameters
+The ``ssh_access`` section is for configuring the SSH access parameters of the X-Road Security Server Toolkit
+The ``security_server`` section is for configuring security server parameters
 
 * <SECURITY_SERVER_CREDENTIALS> X-Road Security Server admin credentials, e.g. xrd:secret (if specified in ``ssh_access`` section, one value will be 
   used for all configurable security servers, but if specified in the ``security_server`` section, the value will be overridden for specific 

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -2,7 +2,7 @@
 
 **Technical Specification**
 
-Version: 1.2.5
+Version: 1.2.6
 Doc. ID: XRDSST-CONF
 
 ---
@@ -27,7 +27,7 @@ Doc. ID: XRDSST-CONF
 | 17.03.2021 | 1.2.3       | Describe failure interpretation and recovery                                 | Taimo Peelo        |
 | 22.03.2021 | 1.2.4       | Default configuration from config/base.yaml -> config/xrdsst.yml             | Taimo Peelo        |
 | 26.03.2021 | 1.2.5       | Add 'fqdn' key for security server, fix service field descriptions           | Taimo Peelo        |
-
+| 29.03.2021 | 1.2.6       | Move api_key section into security server section                            | Bert Viikmäe       |
 
 ## Table of Contents <!-- omit in toc -->
 

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -110,8 +110,8 @@ $ pip install setup.py
   
 ### 3.2 Format of configuration file
 ```
+admin_credentials: <SECURITY_SERVER_CREDENTIALS>
 ssh_access:
-  admin_credentials: <SECURITY_SERVER_CREDENTIALS>
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
 security_server:
@@ -165,7 +165,7 @@ security_server:
 The ``ssh_access`` section is for configuring the SSH access parameters of the X-Road Security Server Toolkit
 The ``security_server`` section is for configuring security server parameters
 
-* <SECURITY_SERVER_CREDENTIALS> X-Road Security Server admin credentials, e.g. xrd:secret (if specified in ``ssh_access`` section, one value will be 
+* <SECURITY_SERVER_CREDENTIALS> X-Road Security Server admin credentials, e.g. xrd:secret (if specified in the separate section, one value will be 
   used for all configurable security servers, but if specified in the ``security_server`` section, the value will be overridden for specific 
   configurable security server)
 * <SSH_USER> SSH username (if specified in ``ssh_access`` section, one value will be used for all configurable security servers, 

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -110,15 +110,15 @@ $ pip install setup.py
   
 ### 3.2 Format of configuration file
 ```
+ssh_access:
+  user: <SSH_USER>
+  private_key: /path/to/ssh_private_key
 security-server:
-- api_key:
-  - key: X-Road-apikey token=<API_KEY>
-    credentials: <SECURITTY_SERVER_CREDENTIALS>
-    ssh_user: <SSH_USER>
-    ssh_key: /path/to/ssh_private_key
-    roles:
+- api_key: X-Road-apikey token=<API_KEY>
+  api_key_roles:
     - <SECURITY_SERVER_ROLE_NAME>
-    url: https://localhost:4000/api/v1/api-keys
+  api_key_url: https://localhost:4000/api/v1/api-keys
+  admin_credentials: <SECURITTY_SERVER_CREDENTIALS>
   configuration_anchor: /path/to/configuration-anchor.xml
   certificates:
     - /path/to/signcert
@@ -133,6 +133,8 @@ security-server:
   software_token_pin: <SOFT_TOKEN_PIN>
   fqdn: <SECURITY_SERVER_EXTERNAL_FQDN>
   url: https://<SECURITY_SERVER_INTERNAL_FQDN_OR_IP>:4000/api/v1
+  ssh_user: <SSH_USER>
+  ssh_private_key: /path/to/ssh_private_key
   clients:
     - member_class: <MEMBER_CLASS>
       member_code: <MEMBER_CODE>
@@ -160,13 +162,19 @@ The ``api-key`` section is for configuring the automatic api key generation para
 The ``logging`` section is for configuring the logging parameters of the X-Road Security Server Toolkit
 The ``security-server`` section is for configuring security server parameters
 
-* <SECURITY_SERVER_CREDENTIALS> X-Road Security Server credentials, e.g. xrd:secret
-* <SSH_USER> SSH username
+* <SECURITY_SERVER_CREDENTIALS> X-Road Security Server admin credentials, e.g. xrd:secret (if specified in ``ssh_access`` section, one value will be 
+  used for all configurable security servers, but if specified in the ``security_server`` section, the value will be overridden for specific 
+  configurable security server)
+* <SSH_USER> SSH username (if specified in ``ssh_access`` section, one value will be used for all configurable security servers, 
+  but if specified in the ``security_server`` section, the value will be overridden for specific configurable security server)
 * ``/path/to/ssh_private_key`` should be substituted with the correct path to the ssh private key file, e.g. home/user/id_rsa
+  (if specified in ``ssh_access`` section, one value will be used for all configurable security servers, 
+  but if specified in the ``security_server`` section, the value will be overridden for specific configurable security server)
 * <SECURITY_SERVER_ROLE_NAME> parameter required for security server api key, should be substituted with a security server role name, e.g. XROAD_SYSTEM_ADMINISTRATOR    
 * ``/path/to/xrdsst.log`` should be substituted with the correct path to the log file, e.g. "/var/log/xroad/xrdsst.log"
 * <LOG_LEVEL> parameter for configuring the logging level for the X-Road Security Server Toolkit, e.g INFO
-* <API_KEY> will be automatically substituted with the api-key of the installed security server
+* <API_KEY> if un-filled, a temporary api key will be automatically created and revoked in the end of a single operation, if filled with value in
+  the format of ``X-Road-apikey token=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx``, that key will be used and a temporary key will not be created
 * ``/path/to/configuration-anchor.xml`` should be substituted with the correct path to the configuration anchor file, e.g. "/etc/xroad/configuration-anchor.xml"
 * <SECURITY_SERVER_NAME> should be substituted with the installed security server name, e.g. ss1
 * <OWNER_DISTINGUISHED_NAME_COUNTRY> should be ISO 3166-1 alpha-2 two letter code for server owner country. This is used in certificate generation.

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -111,16 +111,16 @@ $ pip install setup.py
 ### 3.2 Format of configuration file
 ```
 admin_credentials: <SECURITY_SERVER_CREDENTIALS>
+api_key_roles:
+- XROAD_SYSTEM_ADMINISTRATOR
+- XROAD_SERVICE_ADMINISTRATOR
+- XROAD_SECURITY_OFFICER
+- XROAD_REGISTRATION_OFFICER
 ssh_access:
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
 security_server:
 - api_key: X-Road-apikey token=<API_KEY>
-  api_key_roles:
-  - XROAD_SYSTEM_ADMINISTRATOR
-  - XROAD_SERVICE_ADMINISTRATOR
-  - XROAD_SECURITY_OFFICER
-  - XROAD_REGISTRATION_OFFICER
   api_key_url: https://localhost:4000/api/v1/api-keys
   admin_credentials: <SECURITY_SERVER_CREDENTIALS>
   configuration_anchor: /path/to/configuration-anchor.xml

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -27,7 +27,7 @@ Doc. ID: XRDSST-CONF
 | 17.03.2021 | 1.2.3       | Describe failure interpretation and recovery                                 | Taimo Peelo        |
 | 22.03.2021 | 1.2.4       | Default configuration from config/base.yaml -> config/xrdsst.yml             | Taimo Peelo        |
 | 26.03.2021 | 1.2.5       | Add 'fqdn' key for security server, fix service field descriptions           | Taimo Peelo        |
-| 31.03.2021 | 1.2.6       | Move api_key section into security server section                            | Bert Viikmäe       |
+| 31.03.2021 | 1.2.6       | Refactorization of configuration file related to SSH and api key parameters  | Bert Viikmäe       |
 
 ## Table of Contents <!-- omit in toc -->
 

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -27,7 +27,7 @@ Doc. ID: XRDSST-CONF
 | 17.03.2021 | 1.2.3       | Describe failure interpretation and recovery                                 | Taimo Peelo        |
 | 22.03.2021 | 1.2.4       | Default configuration from config/base.yaml -> config/xrdsst.yml             | Taimo Peelo        |
 | 26.03.2021 | 1.2.5       | Add 'fqdn' key for security server, fix service field descriptions           | Taimo Peelo        |
-| 29.03.2021 | 1.2.6       | Move api_key section into security server section                            | Bert Viikmäe       |
+| 31.03.2021 | 1.2.6       | Move api_key section into security server section                            | Bert Viikmäe       |
 
 ## Table of Contents <!-- omit in toc -->
 
@@ -111,7 +111,7 @@ $ pip install setup.py
 ### 3.2 Format of configuration file
 ```
 ssh_access:
-  admin_credentials: <SECURITTY_SERVER_CREDENTIALS>
+  admin_credentials: <SECURITY_SERVER_CREDENTIALS>
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
 security_server:
@@ -119,7 +119,7 @@ security_server:
   api_key_roles:
     - <SECURITY_SERVER_ROLE_NAME>
   api_key_url: https://localhost:4000/api/v1/api-keys
-  admin_credentials: <SECURITTY_SERVER_CREDENTIALS>
+  admin_credentials: <SECURITY_SERVER_CREDENTIALS>
   configuration_anchor: /path/to/configuration-anchor.xml
   certificates:
     - /path/to/signcert

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -117,7 +117,10 @@ ssh_access:
 security_server:
 - api_key: X-Road-apikey token=<API_KEY>
   api_key_roles:
-    - <SECURITY_SERVER_ROLE_NAME>
+  - XROAD_SYSTEM_ADMINISTRATOR
+  - XROAD_SERVICE_ADMINISTRATOR
+  - XROAD_SECURITY_OFFICER
+  - XROAD_REGISTRATION_OFFICER
   api_key_url: https://localhost:4000/api/v1/api-keys
   admin_credentials: <SECURITY_SERVER_CREDENTIALS>
   configuration_anchor: /path/to/configuration-anchor.xml
@@ -169,8 +172,7 @@ The ``security_server`` section is for configuring security server parameters
   but if specified in the ``security_server`` section, the value will be overridden for specific configurable security server)
 * ``/path/to/ssh_private_key`` should be substituted with the correct path to the ssh private key file, e.g. home/user/id_rsa
   (if specified in ``ssh_access`` section, one value will be used for all configurable security servers, 
-  but if specified in the ``security_server`` section, the value will be overridden for specific configurable security server)
-* <SECURITY_SERVER_ROLE_NAME> parameter required for security server api key, should be substituted with a security server role name, e.g. XROAD_SYSTEM_ADMINISTRATOR    
+  but if specified in the ``security_server`` section, the value will be overridden for specific configurable security server)  
 * ``/path/to/xrdsst.log`` should be substituted with the correct path to the log file, e.g. "/var/log/xroad/xrdsst.log"
 * <LOG_LEVEL> parameter for configuring the logging level for the X-Road Security Server Toolkit, e.g INFO
 * <API_KEY> if un-filled, a temporary api key will be automatically created and revoked in the end of a single operation, if filled with value in

--- a/run_end_to_end_tests.sh
+++ b/run_end_to_end_tests.sh
@@ -46,9 +46,9 @@ exit_abnormal() {
 update_config() {
   local cmd
   cmd=""
-  cmd=".security_server[0].api_key[0].ssh_key=\"$5\""
-  cmd="${cmd}|.security_server[0].api_key[0].credentials=\"$6\""
-  cmd="${cmd}|.security_server[0].api_key[0].ssh_user=\"$8\""
+  cmd=".security_server[0].ssh_private_key=\"$5\""
+  cmd="${cmd}|.security_server[0].admin_credentials=\"$6\""
+  cmd="${cmd}|.security_server[0].ssh_user=\"$8\""
   cmd="${cmd}|.security_server[0].configuration_anchor=\"$2\""
   cmd="${cmd}|.security_server[0].name=\"$4\""
   cmd="${cmd}|.security_server[0].security_server_code=\"$4\""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1-alpha.0
+current_version = 0.3.2-alpha.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)\.(?P<build>\d+))?

--- a/tests/end_to_end/tests.py
+++ b/tests/end_to_end/tests.py
@@ -139,7 +139,7 @@ class EndToEndTest(unittest.TestCase):
         self.config['security_server'][0]['certificates'] = signed_certs
 
     def create_api_key(self, api_key):
-        self.config["security_server"][0]["api_key"] = api_key
+        self.config["security_server"][0]["api_key"][0]["key"] = api_key
 
     def step_cert_import(self):
         with XRDSSTTest() as app:

--- a/tests/end_to_end/tests.py
+++ b/tests/end_to_end/tests.py
@@ -139,7 +139,7 @@ class EndToEndTest(unittest.TestCase):
         self.config['security_server'][0]['certificates'] = signed_certs
 
     def create_api_key(self, api_key):
-        self.config["security_server"][0]["api_key"][0]["key"] = api_key
+        self.config["security_server"][0]["api_key"] = api_key
 
     def step_cert_import(self):
         with XRDSSTTest() as app:

--- a/tests/integration/integration_base.py
+++ b/tests/integration/integration_base.py
@@ -31,29 +31,25 @@ class IntegrationTestBase(unittest.TestCase):
     def init_config(self):
         self.config = {
             'logging': [{'file': '/var/log/xrdsst_test.log', 'level': 'INFO'}],
+            'ssh_access': [{'admin_credentials': self.credentials, 'user': 'user', 'private_key': 'key'}],
             'security_server':
                 [{'name': 'ss',
                   'url': 'https://CONTAINER_HOST:4000/api/v1',
                   'fqdn': 'client_only',
-                  'api_key': [{
-                      'key': 'X-Road-apikey token=a2e9dea1-de53-4ebc-a750-6be6461d91f0',
-                      'credentials': self.credentials,
-                      'ssh_user': 'user',
-                      'ssh_key': 'key',
-                      'roles': json.loads(self.roles),
-                      'url': self.url
-                  }],
+                  'api_key': 'X-Road-apikey token=a2e9dea1-de53-4ebc-a750-6be6461d91f0',
+                  'api_key_roles': json.loads(self.roles),
+                  'api_key_url': self.url,
                   'configuration_anchor': os.path.join(ROOT_DIR, self.configuration_anchor),
-                  'owner_dn_country': 'EE',
+                  'owner_dn_country': 'FI',
                   'owner_dn_org': 'NIIS',
-                  'owner_member_class': 'GOV',
-                  'owner_member_code': '1234',
+                  'owner_member_class': 'ORG',
+                  'owner_member_code': '111',
                   'security_server_code': 'SS',
                   'software_token_id': 0,
                   'software_token_pin': '1234',
                   'clients': [{
-                      'member_class': 'GOV',
-                      'member_code': '1234',
+                      'member_class': 'ORG',
+                      'member_code': '111',
                       'subsystem_code': 'BUS',
                       'connection_type': 'HTTP',
                       'service_descriptions': [{
@@ -85,7 +81,7 @@ class IntegrationTestBase(unittest.TestCase):
         return self.config
 
     def set_api_key(self, api_key):
-        self.config["security_server"][0]["api_key"][0]["key"] = 'X-Road-apikey token=' + api_key
+        self.config["security_server"][0]["api_key"] = 'X-Road-apikey token=' + api_key
 
     def set_ip_url(self, ip_address):
         local_url = self.config["security_server"][0]["url"]

--- a/tests/integration/integration_base.py
+++ b/tests/integration/integration_base.py
@@ -31,6 +31,7 @@ class IntegrationTestBase(unittest.TestCase):
     def init_config(self):
         self.config = {
             'admin_credentials': self.credentials,
+            'api_key_roles': json.loads(self.roles),
             'logging': {'file': '/var/log/xrdsst_test.log', 'level': 'INFO'},
             'ssh_access': {'user': 'user', 'private_key': 'key'},
             'security_server':
@@ -38,7 +39,6 @@ class IntegrationTestBase(unittest.TestCase):
                   'url': 'https://CONTAINER_HOST:4000/api/v1',
                   'fqdn': 'client_only',
                   'api_key': 'X-Road-apikey token=a2e9dea1-de53-4ebc-a750-6be6461d91f0',
-                  'api_key_roles': json.loads(self.roles),
                   'api_key_url': self.url,
                   'configuration_anchor': os.path.join(ROOT_DIR, self.configuration_anchor),
                   'owner_dn_country': 'FI',

--- a/tests/integration/integration_base.py
+++ b/tests/integration/integration_base.py
@@ -30,8 +30,9 @@ class IntegrationTestBase(unittest.TestCase):
 
     def init_config(self):
         self.config = {
+            'admin_credentials': self.credentials,
             'logging': [{'file': '/var/log/xrdsst_test.log', 'level': 'INFO'}],
-            'ssh_access': [{'admin_credentials': self.credentials, 'user': 'user', 'private_key': 'key'}],
+            'ssh_access': [{'user': 'user', 'private_key': 'key'}],
             'security_server':
                 [{'name': 'ss',
                   'url': 'https://CONTAINER_HOST:4000/api/v1',

--- a/tests/integration/integration_base.py
+++ b/tests/integration/integration_base.py
@@ -31,25 +31,29 @@ class IntegrationTestBase(unittest.TestCase):
     def init_config(self):
         self.config = {
             'logging': [{'file': '/var/log/xrdsst_test.log', 'level': 'INFO'}],
-            'api_key': [{'url': self.url,
-                         'key': 'key',
-                         'roles': json.loads(self.roles)}],
             'security_server':
                 [{'name': 'ss',
                   'url': 'https://CONTAINER_HOST:4000/api/v1',
                   'fqdn': 'client_only',
-                  'api_key': 'X-Road-apikey token=a2e9dea1-de53-4ebc-a750-6be6461d91f0',
+                  'api_key': [{
+                      'key': 'X-Road-apikey token=a2e9dea1-de53-4ebc-a750-6be6461d91f0',
+                      'credentials': self.credentials,
+                      'ssh_user': 'user',
+                      'ssh_key': 'key',
+                      'roles': json.loads(self.roles),
+                      'url': self.url
+                  }],
                   'configuration_anchor': os.path.join(ROOT_DIR, self.configuration_anchor),
-                  'owner_dn_country': 'FI',
+                  'owner_dn_country': 'EE',
                   'owner_dn_org': 'NIIS',
-                  'owner_member_class': 'ORG',
-                  'owner_member_code': '111',
+                  'owner_member_class': 'GOV',
+                  'owner_member_code': '1234',
                   'security_server_code': 'SS',
                   'software_token_id': 0,
                   'software_token_pin': '1234',
                   'clients': [{
-                      'member_class': 'ORG',
-                      'member_code': '111',
+                      'member_class': 'GOV',
+                      'member_code': '1234',
                       'subsystem_code': 'BUS',
                       'connection_type': 'HTTP',
                       'service_descriptions': [{
@@ -81,7 +85,7 @@ class IntegrationTestBase(unittest.TestCase):
         return self.config
 
     def set_api_key(self, api_key):
-        self.config["security_server"][0]["api_key"] = 'X-Road-apikey token=' + api_key
+        self.config["security_server"][0]["api_key"][0]["key"] = 'X-Road-apikey token=' + api_key
 
     def set_ip_url(self, ip_address):
         local_url = self.config["security_server"][0]["url"]

--- a/tests/integration/integration_base.py
+++ b/tests/integration/integration_base.py
@@ -31,8 +31,8 @@ class IntegrationTestBase(unittest.TestCase):
     def init_config(self):
         self.config = {
             'admin_credentials': self.credentials,
-            'logging': [{'file': '/var/log/xrdsst_test.log', 'level': 'INFO'}],
-            'ssh_access': [{'user': 'user', 'private_key': 'key'}],
+            'logging': {'file': '/var/log/xrdsst_test.log', 'level': 'INFO'},
+            'ssh_access': {'user': 'user', 'private_key': 'key'},
             'security_server':
                 [{'name': 'ss',
                   'url': 'https://CONTAINER_HOST:4000/api/v1',

--- a/tests/integration/test_xrdsst.py
+++ b/tests/integration/test_xrdsst.py
@@ -130,8 +130,8 @@ class TestXRDSST(IntegrationTestBase, IntegrationOpBase):
             service_controller.load_config = (lambda: self.config)
             service_controller.add_access()
             description = get_service_description(self.config, client_id)
-            #service_clients = get_service_clients(self.config, description["services"][0]["id"])
-            #assert len(service_clients) == 1
+            service_clients = get_service_clients(self.config, description["services"][0]["id"])
+            assert len(service_clients) == 1
 
     def step_update_service_parameters(self, client_id):
         with XRDSSTTest() as app:

--- a/tests/integration/test_xrdsst.py
+++ b/tests/integration/test_xrdsst.py
@@ -130,8 +130,8 @@ class TestXRDSST(IntegrationTestBase, IntegrationOpBase):
             service_controller.load_config = (lambda: self.config)
             service_controller.add_access()
             description = get_service_description(self.config, client_id)
-            service_clients = get_service_clients(self.config, description["services"][0]["id"])
-            assert len(service_clients) == 1
+            #service_clients = get_service_clients(self.config, description["services"][0]["id"])
+            #assert len(service_clients) == 1
 
     def step_update_service_parameters(self, client_id):
         with XRDSSTTest() as app:

--- a/tests/resources/test-config-template.yaml
+++ b/tests/resources/test-config-template.yaml
@@ -1,18 +1,19 @@
+ssh_access:
+  admin_credentials: <SECURITTY_SERVER_CREDENTIALS>
+  user: <SSH_USER>
+  private_key: /path/to/ssh_private_key
 security_server:
-- api_key:
-  - key: X-Road-apikey token=<API_KEY>
-    credentials: <SECURITTY_SERVER_CREDENTIALS>
-    ssh_user: <SSH_USER>
-    ssh_key: /path/to/ssh_private_key
-    roles:
-    - XROAD_SYSTEM_ADMINISTRATOR
-    - XROAD_SERVICE_ADMINISTRATOR
-    - XROAD_SECURITY_OFFICER
-    - XROAD_REGISTRATION_OFFICER
-    url: https://localhost:4000/api/v1/api-keys
+- api_key: X-Road-apikey token=<API_KEY>
+  api_key_roles:
+  - XROAD_SYSTEM_ADMINISTRATOR
+  - XROAD_SERVICE_ADMINISTRATOR
+  - XROAD_SECURITY_OFFICER
+  - XROAD_REGISTRATION_OFFICER
+  api_key_url: https://localhost:4000/api/v1/api-keys
+  admin_credentials:
   certificates:
-    - /path/to/signcert
-    - /path/to/authcert
+    - /home/bertvi/x/ss3-sign.pem
+    - /home/bertvi/x/ss3-auth.pem
   configuration_anchor: /path/to/configuration-anchor.xml
   name: <SECURITY_SERVER_NAME>
   owner_dn_country: FI
@@ -24,6 +25,8 @@ security_server:
   software_token_pin: 1234
   fqdn: client_only
   url: https://<SECURITY_SERVER_FQDN_OR_IP>:4000/api/v1
+  ssh_user:
+  ssh_private_key:
   clients:
     - member_class: ORG
       member_code: 111

--- a/tests/resources/test-config-template.yaml
+++ b/tests/resources/test-config-template.yaml
@@ -1,5 +1,5 @@
+admin_credentials: <SECURITY_SERVER_CREDENTIALS>
 ssh_access:
-  admin_credentials: <SECURITY_SERVER_CREDENTIALS>
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
 security_server:

--- a/tests/resources/test-config-template.yaml
+++ b/tests/resources/test-config-template.yaml
@@ -1,5 +1,5 @@
 ssh_access:
-  admin_credentials: <SECURITTY_SERVER_CREDENTIALS>
+  admin_credentials: <SECURITY_SERVER_CREDENTIALS>
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
 security_server:
@@ -12,8 +12,8 @@ security_server:
   api_key_url: https://localhost:4000/api/v1/api-keys
   admin_credentials:
   certificates:
-    - /home/bertvi/x/ss3-sign.pem
-    - /home/bertvi/x/ss3-auth.pem
+    - /path/to/signcert
+    - /path/to/authcert
   configuration_anchor: /path/to/configuration-anchor.xml
   name: <SECURITY_SERVER_NAME>
   owner_dn_country: FI

--- a/tests/resources/test-config-template.yaml
+++ b/tests/resources/test-config-template.yaml
@@ -1,17 +1,15 @@
-api_key:
-- credentials: xrd:secret
-  key: /path/to/ssh_private_key
-  roles:
-  - XROAD_SYSTEM_ADMINISTRATOR
-  - XROAD_SERVICE_ADMINISTRATOR
-  - XROAD_SECURITY_OFFICER
-  - XROAD_REGISTRATION_OFFICER
-  url: https://localhost:4000/api/v1/api-keys
-logging:
-  file: /var/log/xroad/xrdsst.log
-  level: INFO
 security_server:
-- api_key: X-Road-apikey token=<API_KEY>
+- api_key:
+  - key: X-Road-apikey token=<API_KEY>
+    credentials: <SECURITTY_SERVER_CREDENTIALS>
+    ssh_user: <SSH_USER>
+    ssh_key: /path/to/ssh_private_key
+    roles:
+    - XROAD_SYSTEM_ADMINISTRATOR
+    - XROAD_SERVICE_ADMINISTRATOR
+    - XROAD_SECURITY_OFFICER
+    - XROAD_REGISTRATION_OFFICER
+    url: https://localhost:4000/api/v1/api-keys
   certificates:
     - /path/to/signcert
     - /path/to/authcert

--- a/tests/resources/test-config-template.yaml
+++ b/tests/resources/test-config-template.yaml
@@ -1,14 +1,14 @@
 admin_credentials: <SECURITY_SERVER_CREDENTIALS>
+api_key_roles:
+- XROAD_SYSTEM_ADMINISTRATOR
+- XROAD_SERVICE_ADMINISTRATOR
+- XROAD_SECURITY_OFFICER
+- XROAD_REGISTRATION_OFFICER
 ssh_access:
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
 security_server:
 - api_key: X-Road-apikey token=<API_KEY>
-  api_key_roles:
-  - XROAD_SYSTEM_ADMINISTRATOR
-  - XROAD_SERVICE_ADMINISTRATOR
-  - XROAD_SECURITY_OFFICER
-  - XROAD_REGISTRATION_OFFICER
   api_key_url: https://localhost:4000/api/v1/api-keys
   admin_credentials:
   certificates:

--- a/tests/unit/test_auto.py
+++ b/tests/unit/test_auto.py
@@ -19,15 +19,18 @@ from xrdsst.main import XRDSSTTest
 
 class TestAuto(unittest.TestCase):
     ss_config = {
-        'api_key': [{'url': 'https://localhost:4000/api/v1/api-keys',
-                     'key': 'private key',
-                     'credentials': 'user:pass',
-                     'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
-              'api_key': 'X-Road-apikey token=66666666-8000-4011-a000-333336633333'
-              }]}
+              'api_key': [{
+                'key': 'X-Road-apikey token=66666666-8000-4011-a000-333336633333',
+                'credentials': 'user:pass',
+                'ssh_user': 'user',
+                'ssh_key': 'key',
+                'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+                'url': 'https://localhost:4000/api/v1/api-keys'
+              }]
+            }]}
 
     @pytest.fixture(autouse=True)
     def capsys(self, capsys):

--- a/tests/unit/test_auto.py
+++ b/tests/unit/test_auto.py
@@ -19,7 +19,8 @@ from xrdsst.main import XRDSSTTest
 
 class TestAuto(unittest.TestCase):
     ss_config = {
-        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
+        'admin_credentials': 'user:pass',
+        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',

--- a/tests/unit/test_auto.py
+++ b/tests/unit/test_auto.py
@@ -20,12 +20,12 @@ from xrdsst.main import XRDSSTTest
 class TestAuto(unittest.TestCase):
     ss_config = {
         'admin_credentials': 'user:pass',
+        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
               'api_key': 'X-Road-apikey token=66666666-8000-4011-a000-333336633333',
-              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
               'api_key_url': 'https://localhost:4000/api/v1/api-keys'
             }]}
 

--- a/tests/unit/test_auto.py
+++ b/tests/unit/test_auto.py
@@ -19,17 +19,13 @@ from xrdsst.main import XRDSSTTest
 
 class TestAuto(unittest.TestCase):
     ss_config = {
+        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
-              'api_key': [{
-                'key': 'X-Road-apikey token=66666666-8000-4011-a000-333336633333',
-                'credentials': 'user:pass',
-                'ssh_user': 'user',
-                'ssh_key': 'key',
-                'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
-                'url': 'https://localhost:4000/api/v1/api-keys'
-              }]
+              'api_key': 'X-Road-apikey token=66666666-8000-4011-a000-333336633333',
+              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+              'api_key_url': 'https://localhost:4000/api/v1/api-keys'
             }]}
 
     @pytest.fixture(autouse=True)

--- a/tests/unit/test_auto.py
+++ b/tests/unit/test_auto.py
@@ -20,7 +20,7 @@ from xrdsst.main import XRDSSTTest
 class TestAuto(unittest.TestCase):
     ss_config = {
         'admin_credentials': 'user:pass',
-        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
+        'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -22,12 +22,17 @@ class TestBaseController(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     _ss_config = {
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
-        'api_key': [{'url': 'https://localhost:4000/api/v1/api-keys',
-                     'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
         'security_server':
             [{'name': 'ss',
               'url': 'https://ss:4000/api/v1',
-              'api_key': 'X-Road-apikey token=api-key',
+              'api_key': [{
+               'key': 'X-Road-apikey token=<API_KEY>',
+               'credentials': 'user:pass',
+               'ssh_user': 'user',
+               'ssh_key': 'key',
+               'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+               'url': 'https://localhost:4000/api/v1/api-keys'
+              }],
               'configuration_anchor': configuration_anchor,
               'owner_member_class': 'GOV',
               'owner_member_code': '1234',
@@ -327,10 +332,10 @@ class TestBaseController(unittest.TestCase):
                 temp_file_name = os.path.join(ROOT_DIR, "conf.yaml")
                 config = self.create_temp_conf(base_controller, temp_file_name)
                 security_server = config["security_server"][0]
-                security_server["api_key"] = 'X-Road-apikey token=some key'
+                security_server["api_key"][0]["key"] = 'X-Road-apikey token=some key'
                 key = base_controller.get_api_key(config, security_server)
                 assert key != 'X-Road-apikey token=api-key-123'
-                security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'
+                security_server["api_key"][0]["key"] = 'X-Road-apikey token=<API_KEY>'
                 key = base_controller.get_api_key(config, security_server)
                 os.remove(temp_file_name)
                 assert key == 'X-Road-apikey token=88888888-8000-4000-a000-727272727272'
@@ -342,7 +347,7 @@ class TestBaseController(unittest.TestCase):
             temp_file_name = os.path.join(ROOT_DIR, "conf.yaml")
             config = self.create_temp_conf(base_controller, temp_file_name)
             security_server = config["security_server"][0]
-            security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'
+            security_server["api_key"][0]["key"] = 'X-Road-apikey token=<API_KEY>'
             base_controller.get_api_key(config, security_server)
             os.remove(temp_file_name)
             self.assertRaises(Exception)
@@ -355,9 +360,9 @@ class TestBaseController(unittest.TestCase):
             config = self.create_temp_conf(base_controller, temp_file_name)
             temp_key_file = open("my_key", "w")
             temp_key_file.close()
-            config["api_key"][0]["key"] = "my_key"
             security_server = config["security_server"][0]
-            security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'
+            security_server["api_key"][0]["ssh_key"] = 'my_key'
+            security_server["api_key"][0]["key"] = 'X-Road-apikey token=<API_KEY>'
             base_controller.get_api_key(config, security_server)
             os.remove(temp_file_name)
             os.remove("my_key")

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -21,8 +21,9 @@ from xrdsst.models import ConnectionType
 class TestBaseController(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     _ss_config = {
+        'admin_credentials': 'user:pass',
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
-        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
+        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ss',
               'url': 'https://ss:4000/api/v1',

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -22,17 +22,13 @@ class TestBaseController(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     _ss_config = {
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
+        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ss',
               'url': 'https://ss:4000/api/v1',
-              'api_key': [{
-               'key': 'X-Road-apikey token=<API_KEY>',
-               'credentials': 'user:pass',
-               'ssh_user': 'user',
-               'ssh_key': 'key',
-               'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
-               'url': 'https://localhost:4000/api/v1/api-keys'
-              }],
+              'api_key': 'X-Road-apikey token=<API_KEY>',
+              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+              'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'configuration_anchor': configuration_anchor,
               'owner_member_class': 'GOV',
               'owner_member_code': '1234',
@@ -332,10 +328,10 @@ class TestBaseController(unittest.TestCase):
                 temp_file_name = os.path.join(ROOT_DIR, "conf.yaml")
                 config = self.create_temp_conf(base_controller, temp_file_name)
                 security_server = config["security_server"][0]
-                security_server["api_key"][0]["key"] = 'X-Road-apikey token=some key'
+                security_server["api_key"] = 'X-Road-apikey token=some key'
                 key = base_controller.get_api_key(config, security_server)
                 assert key != 'X-Road-apikey token=api-key-123'
-                security_server["api_key"][0]["key"] = 'X-Road-apikey token=<API_KEY>'
+                security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'
                 key = base_controller.get_api_key(config, security_server)
                 os.remove(temp_file_name)
                 assert key == 'X-Road-apikey token=88888888-8000-4000-a000-727272727272'
@@ -347,7 +343,7 @@ class TestBaseController(unittest.TestCase):
             temp_file_name = os.path.join(ROOT_DIR, "conf.yaml")
             config = self.create_temp_conf(base_controller, temp_file_name)
             security_server = config["security_server"][0]
-            security_server["api_key"][0]["key"] = 'X-Road-apikey token=<API_KEY>'
+            security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'
             base_controller.get_api_key(config, security_server)
             os.remove(temp_file_name)
             self.assertRaises(Exception)
@@ -360,9 +356,10 @@ class TestBaseController(unittest.TestCase):
             config = self.create_temp_conf(base_controller, temp_file_name)
             temp_key_file = open("my_key", "w")
             temp_key_file.close()
+            ssh_access = config["ssh_access"][0]
             security_server = config["security_server"][0]
-            security_server["api_key"][0]["ssh_key"] = 'my_key'
-            security_server["api_key"][0]["key"] = 'X-Road-apikey token=<API_KEY>'
+            ssh_access["private_key"] = 'my_key'
+            security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'
             base_controller.get_api_key(config, security_server)
             os.remove(temp_file_name)
             os.remove("my_key")

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -23,7 +23,7 @@ class TestBaseController(unittest.TestCase):
     _ss_config = {
         'admin_credentials': 'user:pass',
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
-        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
+        'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ss',
               'url': 'https://ss:4000/api/v1',
@@ -357,7 +357,7 @@ class TestBaseController(unittest.TestCase):
             config = self.create_temp_conf(base_controller, temp_file_name)
             temp_key_file = open("my_key", "w")
             temp_key_file.close()
-            ssh_access = config["ssh_access"][0]
+            ssh_access = config["ssh_access"]
             security_server = config["security_server"][0]
             ssh_access["private_key"] = 'my_key'
             security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -22,13 +22,13 @@ class TestBaseController(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     _ss_config = {
         'admin_credentials': 'user:pass',
+        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ss',
               'url': 'https://ss:4000/api/v1',
               'api_key': 'X-Road-apikey token=<API_KEY>',
-              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'configuration_anchor': configuration_anchor,
               'owner_member_class': 'GOV',

--- a/tests/unit/test_cert.py
+++ b/tests/unit/test_cert.py
@@ -244,8 +244,8 @@ class TestCert(unittest.TestCase):
     authcert_existing = os.path.join(ROOT_DIR, "tests/resources/authcert.pem")
     ss_config = {
         'admin_credentials': 'user:pass',
-        'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
+        'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
+        'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',

--- a/tests/unit/test_cert.py
+++ b/tests/unit/test_cert.py
@@ -244,10 +244,6 @@ class TestCert(unittest.TestCase):
     authcert_existing = os.path.join(ROOT_DIR, "tests/resources/authcert.pem")
     ss_config = {
         'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'api_key': [{'url': 'https://localhost:4000/api/v1/api-keys',
-                     'key': 'private key',
-                     'credentials': 'user:pass',
-                     'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
@@ -255,7 +251,14 @@ class TestCert(unittest.TestCase):
                   '/some/where/authcert',
                   '/some/where/signcert',
               ],
-              'api_key': 'X-Road-apikey token=88888888-8000-4000-a000-727272727272',
+              'api_key': [{
+                  'key': 'X-Road-apikey token=88888888-8000-4000-a000-727272727272',
+                  'credentials': 'user:pass',
+                  'ssh_user': 'user',
+                  'ssh_key': 'key',
+                  'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+                  'url': 'https://localhost:4000/api/v1/api-keys'
+              }],
               'owner_dn_country': 'FI',
               'owner_dn_org': 'UNSERE',
               'owner_member_class': 'VOG',

--- a/tests/unit/test_cert.py
+++ b/tests/unit/test_cert.py
@@ -244,6 +244,7 @@ class TestCert(unittest.TestCase):
     authcert_existing = os.path.join(ROOT_DIR, "tests/resources/authcert.pem")
     ss_config = {
         'admin_credentials': 'user:pass',
+        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
@@ -254,7 +255,6 @@ class TestCert(unittest.TestCase):
                   '/some/where/signcert',
               ],
               'api_key': 'X-Road-apikey token=88888888-8000-4000-a000-727272727272',
-              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'owner_dn_country': 'FI',
               'owner_dn_org': 'UNSERE',

--- a/tests/unit/test_cert.py
+++ b/tests/unit/test_cert.py
@@ -243,8 +243,9 @@ class CertTestData:
 class TestCert(unittest.TestCase):
     authcert_existing = os.path.join(ROOT_DIR, "tests/resources/authcert.pem")
     ss_config = {
+        'admin_credentials': 'user:pass',
         'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
+        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',

--- a/tests/unit/test_cert.py
+++ b/tests/unit/test_cert.py
@@ -244,6 +244,7 @@ class TestCert(unittest.TestCase):
     authcert_existing = os.path.join(ROOT_DIR, "tests/resources/authcert.pem")
     ss_config = {
         'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
+        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
@@ -251,14 +252,9 @@ class TestCert(unittest.TestCase):
                   '/some/where/authcert',
                   '/some/where/signcert',
               ],
-              'api_key': [{
-                  'key': 'X-Road-apikey token=88888888-8000-4000-a000-727272727272',
-                  'credentials': 'user:pass',
-                  'ssh_user': 'user',
-                  'ssh_key': 'key',
-                  'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
-                  'url': 'https://localhost:4000/api/v1/api-keys'
-              }],
+              'api_key': 'X-Road-apikey token=88888888-8000-4000-a000-727272727272',
+              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+              'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'owner_dn_country': 'FI',
               'owner_dn_org': 'UNSERE',
               'owner_member_class': 'VOG',

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -31,13 +31,13 @@ class ClientTestData:
 class TestClient(unittest.TestCase):
     ss_config = {
         'admin_credentials': 'user:pass',
+        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
               'api_key': 'X-Road-apikey token=55555555-5000-4000-a000-707070707070',
-              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'clients': [
                   {

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -31,17 +31,13 @@ class ClientTestData:
 class TestClient(unittest.TestCase):
     ss_config = {
         'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
+        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
-              'api_key': [{
-                  'key': 'X-Road-apikey token=55555555-5000-4000-a000-707070707070',
-                  'credentials': 'user:pass',
-                  'ssh_user': 'user',
-                  'ssh_key': 'key',
-                  'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
-                  'url': 'https://localhost:4000/api/v1/api-keys'
-              }],
+              'api_key': 'X-Road-apikey token=55555555-5000-4000-a000-707070707070',
+              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+              'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'clients': [
                   {
                       'member_class': 'GOV',

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -31,14 +31,17 @@ class ClientTestData:
 class TestClient(unittest.TestCase):
     ss_config = {
         'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'api_key': [{'url': 'https://localhost:4000/api/v1/api-keys',
-                     'key': 'private key',
-                     'credentials': 'user:pass',
-                     'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
-              'api_key': 'X-Road-apikey token=55555555-5000-4000-a000-707070707070',
+              'api_key': [{
+                  'key': 'X-Road-apikey token=55555555-5000-4000-a000-707070707070',
+                  'credentials': 'user:pass',
+                  'ssh_user': 'user',
+                  'ssh_key': 'key',
+                  'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+                  'url': 'https://localhost:4000/api/v1/api-keys'
+              }],
               'clients': [
                   {
                       'member_class': 'GOV',

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -30,8 +30,9 @@ class ClientTestData:
 
 class TestClient(unittest.TestCase):
     ss_config = {
+        'admin_credentials': 'user:pass',
         'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
+        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -31,8 +31,8 @@ class ClientTestData:
 class TestClient(unittest.TestCase):
     ss_config = {
         'admin_credentials': 'user:pass',
-        'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
+        'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
+        'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -33,12 +33,17 @@ class TestInit(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     _ss_config = {
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
-        'api_key': [{'url': 'https://localhost:4000/api/v1/api-keys',
-                     'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
         'security_server':
             [{'name': 'ss',
               'url': 'https://no.there.com:4000/api/v1',
-              'api_key': 'X-Road-apikey token=api-key',
+              'api_key': [{
+               'key': 'X-Road-apikey token=<API_KEY>',
+               'credentials': 'user:pass',
+               'ssh_user': 'user',
+               'ssh_key': 'key',
+               'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+               'url': 'https://localhost:4000/api/v1/api-keys'
+              }],
               'configuration_anchor': configuration_anchor,
               'owner_member_class': 'GOV',
               'owner_member_code': '1234',

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -33,13 +33,13 @@ class TestInit(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     _ss_config = {
         'admin_credentials': 'user:pass',
+        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ss',
               'url': 'https://no.there.com:4000/api/v1',
               'api_key': 'X-Road-apikey token=<API_KEY>',
-              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'configuration_anchor': configuration_anchor,
               'owner_member_class': 'GOV',

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -32,8 +32,9 @@ UNINITIALIZED_STATUS = InitializationStatus(is_anchor_imported=False, is_server_
 class TestInit(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     _ss_config = {
+        'admin_credentials': 'user:pass',
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
-        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
+        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ss',
               'url': 'https://no.there.com:4000/api/v1',

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -33,17 +33,13 @@ class TestInit(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     _ss_config = {
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
+        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ss',
               'url': 'https://no.there.com:4000/api/v1',
-              'api_key': [{
-               'key': 'X-Road-apikey token=<API_KEY>',
-               'credentials': 'user:pass',
-               'ssh_user': 'user',
-               'ssh_key': 'key',
-               'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
-               'url': 'https://localhost:4000/api/v1/api-keys'
-              }],
+              'api_key': 'X-Road-apikey token=<API_KEY>',
+              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+              'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'configuration_anchor': configuration_anchor,
               'owner_member_class': 'GOV',
               'owner_member_code': '1234',

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -34,7 +34,7 @@ class TestInit(unittest.TestCase):
     _ss_config = {
         'admin_credentials': 'user:pass',
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
-        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
+        'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ss',
               'url': 'https://no.there.com:4000/api/v1',

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -35,8 +35,9 @@ class ServiceTestData:
 
 class TestService(unittest.TestCase):
     ss_config = {
+        'admin_credentials': 'user:pass',
         'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
+        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -43,7 +43,14 @@ class TestService(unittest.TestCase):
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
-              'api_key': 'X-Road-apikey token=33333333-3000-4000-b000-939393939393',
+              'api_key': [{
+                  'key': 'X-Road-apikey token=33333333-3000-4000-b000-939393939393',
+                  'credentials': 'user:pass',
+                  'ssh_user': 'user',
+                  'ssh_key': 'key',
+                  'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+                  'url': 'https://localhost:4000/api/v1/api-keys'
+              }],
               'clients': [
                   {
                       'member_class': 'GOV',

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -36,21 +36,13 @@ class ServiceTestData:
 class TestService(unittest.TestCase):
     ss_config = {
         'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'api_key': [{'url': 'https://localhost:4000/api/v1/api-keys',
-                     'key': 'private key',
-                     'credentials': 'user:pass',
-                     'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
+        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
-              'api_key': [{
-                  'key': 'X-Road-apikey token=33333333-3000-4000-b000-939393939393',
-                  'credentials': 'user:pass',
-                  'ssh_user': 'user',
-                  'ssh_key': 'key',
-                  'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
-                  'url': 'https://localhost:4000/api/v1/api-keys'
-              }],
+              'api_key': 'X-Road-apikey token=33333333-3000-4000-b000-939393939393',
+              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+              'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'clients': [
                   {
                       'member_class': 'GOV',

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -36,13 +36,13 @@ class ServiceTestData:
 class TestService(unittest.TestCase):
     ss_config = {
         'admin_credentials': 'user:pass',
+        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
               'api_key': 'X-Road-apikey token=33333333-3000-4000-b000-939393939393',
-              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'clients': [
                   {

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -36,8 +36,8 @@ class ServiceTestData:
 class TestService(unittest.TestCase):
     ss_config = {
         'admin_credentials': 'user:pass',
-        'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
+        'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
+        'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -25,8 +25,8 @@ class TestStatus(unittest.TestCase):
     authcert_existing = os.path.join(ROOT_DIR, "tests/resources/authcert.pem")
     ss_config = {
         'admin_credentials': 'user:pass',
-        'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
+        'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
+        'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'longServerName',
               'url': 'https://unrealz5BAlxpy9yo0XpplIQbPC.com:443',

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -25,6 +25,7 @@ class TestStatus(unittest.TestCase):
     authcert_existing = os.path.join(ROOT_DIR, "tests/resources/authcert.pem")
     ss_config = {
         'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
+        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'longServerName',
               'url': 'https://unrealz5BAlxpy9yo0XpplIQbPC.com:443',
@@ -32,14 +33,9 @@ class TestStatus(unittest.TestCase):
                   '/some/where/authcert',
                   '/some/where/signcert',
               ],
-              'api_key': [{
-                  'key': 'X-Road-apikey token=86668888-8000-4000-a000-277727227272',
-                  'credentials': 'user:pass',
-                  'ssh_user': 'user',
-                  'ssh_key': 'private key',
-                  'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
-                  'url': 'https://localhost:4000/api/v1/api-keys'
-              }],
+              'api_key': 'X-Road-apikey token=86668888-8000-4000-a000-277727227272',
+              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+              'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'owner_dn_country': 'FI',
               'owner_dn_org': 'UNSERE',
               'owner_member_class': 'VOG',

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -25,6 +25,7 @@ class TestStatus(unittest.TestCase):
     authcert_existing = os.path.join(ROOT_DIR, "tests/resources/authcert.pem")
     ss_config = {
         'admin_credentials': 'user:pass',
+        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
@@ -35,7 +36,6 @@ class TestStatus(unittest.TestCase):
                   '/some/where/signcert',
               ],
               'api_key': 'X-Road-apikey token=86668888-8000-4000-a000-277727227272',
-              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'owner_dn_country': 'FI',
               'owner_dn_org': 'UNSERE',

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -25,10 +25,6 @@ class TestStatus(unittest.TestCase):
     authcert_existing = os.path.join(ROOT_DIR, "tests/resources/authcert.pem")
     ss_config = {
         'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'api_key': [{'url': 'https://localhost:4000/api/v1/api-keys',
-                     'key': 'private key',
-                     'credentials': 'user:pass',
-                     'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
         'security_server':
             [{'name': 'longServerName',
               'url': 'https://unrealz5BAlxpy9yo0XpplIQbPC.com:443',
@@ -36,7 +32,14 @@ class TestStatus(unittest.TestCase):
                   '/some/where/authcert',
                   '/some/where/signcert',
               ],
-              'api_key': 'X-Road-apikey token=86668888-8000-4000-a000-277727227272',
+              'api_key': [{
+                  'key': 'X-Road-apikey token=86668888-8000-4000-a000-277727227272',
+                  'credentials': 'user:pass',
+                  'ssh_user': 'user',
+                  'ssh_key': 'private key',
+                  'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+                  'url': 'https://localhost:4000/api/v1/api-keys'
+              }],
               'owner_dn_country': 'FI',
               'owner_dn_org': 'UNSERE',
               'owner_member_class': 'VOG',

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -24,8 +24,9 @@ def sysadm_secoff(opt_p):
 class TestStatus(unittest.TestCase):
     authcert_existing = os.path.join(ROOT_DIR, "tests/resources/authcert.pem")
     ss_config = {
+        'admin_credentials': 'user:pass',
         'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
+        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'longServerName',
               'url': 'https://unrealz5BAlxpy9yo0XpplIQbPC.com:443',

--- a/tests/unit/test_timestamp.py
+++ b/tests/unit/test_timestamp.py
@@ -29,13 +29,13 @@ class TestTimestamp(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     ss_config = {
         'admin_credentials': 'user:pass',
+        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ss',
               'url': 'https://ss:4000/api/v1',
               'api_key': 'X-Road-apikey token=<API_KEY>',
-              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'configuration_anchor': configuration_anchor,
               'owner_member_class': 'GOV',

--- a/tests/unit/test_timestamp.py
+++ b/tests/unit/test_timestamp.py
@@ -28,8 +28,9 @@ class TimestampTestData:
 class TestTimestamp(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     ss_config = {
+        'admin_credentials': 'user:pass',
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
-        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
+        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ss',
               'url': 'https://ss:4000/api/v1',

--- a/tests/unit/test_timestamp.py
+++ b/tests/unit/test_timestamp.py
@@ -30,7 +30,7 @@ class TestTimestamp(unittest.TestCase):
     ss_config = {
         'admin_credentials': 'user:pass',
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
-        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
+        'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ss',
               'url': 'https://ss:4000/api/v1',

--- a/tests/unit/test_timestamp.py
+++ b/tests/unit/test_timestamp.py
@@ -29,12 +29,17 @@ class TestTimestamp(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     ss_config = {
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
-        'api_key': [{'url': 'https://localhost:4000/api/v1/api-keys',
-                     'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
         'security_server':
             [{'name': 'ss',
               'url': 'https://ss:4000/api/v1',
-              'api_key': 'X-Road-apikey token=api-key',
+              'api_key': [{
+               'key': 'X-Road-apikey token=<API_KEY>',
+               'credentials': 'user:pass',
+               'ssh_user': 'user',
+               'ssh_key': 'key',
+               'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+               'url': 'https://localhost:4000/api/v1/api-keys'
+              }],
               'configuration_anchor': configuration_anchor,
               'owner_member_class': 'GOV',
               'owner_member_code': '1234',

--- a/tests/unit/test_timestamp.py
+++ b/tests/unit/test_timestamp.py
@@ -29,17 +29,13 @@ class TestTimestamp(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     ss_config = {
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
+        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ss',
               'url': 'https://ss:4000/api/v1',
-              'api_key': [{
-               'key': 'X-Road-apikey token=<API_KEY>',
-               'credentials': 'user:pass',
-               'ssh_user': 'user',
-               'ssh_key': 'key',
-               'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
-               'url': 'https://localhost:4000/api/v1/api-keys'
-              }],
+              'api_key': 'X-Road-apikey token=<API_KEY>',
+              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+              'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'configuration_anchor': configuration_anchor,
               'owner_member_class': 'GOV',
               'owner_member_code': '1234',

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -150,8 +150,9 @@ class TokenTestData:
 class TestToken(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     ss_config = {
+        'admin_credentials': 'user:pass',
         'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
+        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -151,8 +151,8 @@ class TestToken(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     ss_config = {
         'admin_credentials': 'user:pass',
-        'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'ssh_access': [{'user': 'user', 'private_key': 'key'}],
+        'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
+        'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -151,15 +151,18 @@ class TestToken(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     ss_config = {
         'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
-        'api_key': [{'url': 'https://localhost:4000/api/v1/api-keys',
-                     'key': 'private key',
-                     'credentials': 'user:pass',
-                     'roles': 'XROAD_SYSTEM_ADMINISTRATOR'}],
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
               'fqdn': 'client_only',
-              'api_key': 'X-Road-apikey token=86668888-8000-4000-a000-277727227272',
+              'api_key': [{
+                  'key': 'X-Road-apikey token=86668888-8000-4000-a000-277727227272',
+                  'credentials': 'user:pass',
+                  'ssh_user': 'user',
+                  'ssh_key': 'key',
+                  'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+                  'url': 'https://localhost:4000/api/v1/api-keys'
+              }],
               'configuration_anchor': configuration_anchor,
               'owner_dn_country': 'FI',
               'owner_dn_org': 'UNSERE',

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -151,6 +151,7 @@ class TestToken(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     ss_config = {
         'admin_credentials': 'user:pass',
+        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
@@ -158,7 +159,6 @@ class TestToken(unittest.TestCase):
               'url': 'https://non.existing.url.blah:8999/api/v1',
               'fqdn': 'client_only',
               'api_key': 'X-Road-apikey token=86668888-8000-4000-a000-277727227272',
-              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'configuration_anchor': configuration_anchor,
               'owner_dn_country': 'FI',

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -151,18 +151,14 @@ class TestToken(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     ss_config = {
         'logging': [{'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'}],
+        'ssh_access': [{'admin_credentials': 'user:pass', 'user': 'user', 'private_key': 'key'}],
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
               'fqdn': 'client_only',
-              'api_key': [{
-                  'key': 'X-Road-apikey token=86668888-8000-4000-a000-277727227272',
-                  'credentials': 'user:pass',
-                  'ssh_user': 'user',
-                  'ssh_key': 'key',
-                  'roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
-                  'url': 'https://localhost:4000/api/v1/api-keys'
-              }],
+              'api_key': 'X-Road-apikey token=86668888-8000-4000-a000-277727227272',
+              'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
+              'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'configuration_anchor': configuration_anchor,
               'owner_dn_country': 'FI',
               'owner_dn_org': 'UNSERE',

--- a/tests/unit/test_xrdsst.py
+++ b/tests/unit/test_xrdsst.py
@@ -1,6 +1,6 @@
 from xrdsst.controllers.base import BaseController
 from xrdsst.core.excplanation import http_status_code_to_text
-from xrdsst.core.util import default_sign_key_label, default_auth_key_label
+from xrdsst.core.util import default_sign_key_label, default_auth_key_label, get_admin_credentials, get_ssh_user, get_ssh_key
 from xrdsst.main import opdep_init
 
 
@@ -14,6 +14,77 @@ def test_opdep_init_adds_app_opdep():
     assert mock_app.OP_DEPENDENCY_LIST
     assert mock_app.OP_GRAPH.number_of_nodes() == len(mock_app.OP_DEPENDENCY_LIST)
 
+def test_admin_credentials_from_root_level_when_empty_at_security_server_section():
+    config = {
+        'admin_credentials': 'admin:pass',
+        'ssh_access': {'user': 'user', 'private_key': 'key'},
+        'security_server':
+            [{'admin_credentials': 'another_admin:another_pass',
+              'ssh_user': 'ssh_user',
+              'ssh_private_key': 'private_key'}]}
+    security_server = {
+            'admin_credentials': '',
+            'ssh_user': '',
+            'ssh_private_key': ''}
+    assert 'admin:pass' == get_admin_credentials(security_server, config)
+
+def test_admin_credentials_from_root_level_when_missing_at_security_server_section():
+    config = {
+        'admin_credentials': 'admin:pass',
+        'ssh_access': {'user': 'user', 'private_key': 'key'},
+        'security_server':
+            [{'admin_credentials': 'another_admin:another_pass',
+              'ssh_user': 'ssh_user',
+              'ssh_private_key': 'private_key'}]}
+    security_server = {}
+    assert 'admin:pass' == get_admin_credentials(security_server, config)
+
+def test_admin_credentials_from_security_server_section_when_empty_at_root_level():
+    config = {
+        'admin_credentials': '',
+        'ssh_access': {'user': 'user', 'private_key': 'key'},
+        'security_server':
+            [{'admin_credentials': 'another_admin:another_pass',
+              'ssh_user': 'ssh_user',
+              'ssh_private_key': 'private_key'}]}
+    security_server = {
+            'admin_credentials': 'another_admin:another_pass',
+            'ssh_user': '',
+            'ssh_private_key': ''}
+    assert 'another_admin:another_pass' == get_admin_credentials(security_server, config)
+
+def test_ssh_values_from_root_level_when_empty_at_security_server_section():
+    config = {
+        'ssh_access': {'user': 'user', 'private_key': 'key'},
+        'security_server':
+            [{'ssh_user': 'ssh_user',
+              'ssh_private_key': 'private_key'}]}
+    security_server = {
+            'ssh_user': '',
+            'ssh_private_key': ''}
+    assert 'user' == get_ssh_user(security_server, config)
+    assert 'key' == get_ssh_key(security_server, config)
+
+def test_ssh_values_from_root_level_when_missing_at_security_server_section():
+    config = {
+        'ssh_access': {'user': 'user', 'private_key': 'key'},
+        'security_server':
+            [{'ssh_user': 'ssh_user',
+              'ssh_private_key': 'private_key'}]}
+    security_server = {}
+    assert 'user' == get_ssh_user(security_server, config)
+    assert 'key' == get_ssh_key(security_server, config)
+
+def test_ssh_values_from_security_server_section_when_missing_at_root_level():
+    config = {
+        'security_server':
+            [{'ssh_user': 'ssh_user',
+              'ssh_private_key': 'private_key'}]}
+    security_server = {
+            'ssh_user': 'another_user',
+            'ssh_private_key': 'another_key'}
+    assert 'another_user' == get_ssh_user(security_server, config)
+    assert 'another_key' == get_ssh_key(security_server, config)
 
 def test_default_sign_key_label():
     security_server_config = {'name': 'ss-name1'}

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -266,7 +266,7 @@ def get_service_description(config, client_id):
     return api_GET(
             config["security_server"][0]["url"],
             "clients/" + client_id + "/service-descriptions",
-            config["security_server"][0]["api_key"]
+            config["security_server"][0]["api_key"][0]["key"]
         )[0]
 
 # Returns service clients for given service
@@ -274,7 +274,7 @@ def get_service_clients(config, service_id):
     return api_GET(
             config["security_server"][0]["url"],
             "services/" + service_id + "/service-clients",
-            config["security_server"][0]["api_key"]
+            config["security_server"][0]["api_key"][0]["key"]
         )
 
 # Returns client
@@ -289,7 +289,7 @@ def get_client(config):
          'member_code': member_code,
          'subsystem_code': subsystem_code,
          'connection_type': conn_type},
-        headers={'Authorization': config["security_server"][0]["api_key"], 'accept': 'application/json'},
+        headers={'Authorization': config["security_server"][0]["api_key"][0]["key"], 'accept': 'application/json'},
         verify=False)
     client_json = json.loads(str(client.content, 'utf-8').strip())
     return client_json[0]
@@ -319,7 +319,7 @@ def auth_cert_registration_global_configuration_update_received(config):
         config["security_server"][0]["url"] + "/tokens/" + str(config["security_server"][0]['software_token_id']),
         None,
         headers={
-            'Authorization': config["security_server"][0]["api_key"],
+            'Authorization': config["security_server"][0]["api_key"][0]["key"],
             'accept': 'application/json'
         },
         verify=False

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -266,7 +266,7 @@ def get_service_description(config, client_id):
     return api_GET(
             config["security_server"][0]["url"],
             "clients/" + client_id + "/service-descriptions",
-            config["security_server"][0]["api_key"][0]["key"]
+            config["security_server"][0]["api_key"]
         )[0]
 
 # Returns service clients for given service
@@ -274,7 +274,7 @@ def get_service_clients(config, service_id):
     return api_GET(
             config["security_server"][0]["url"],
             "services/" + service_id + "/service-clients",
-            config["security_server"][0]["api_key"][0]["key"]
+            config["security_server"][0]["api_key"]
         )
 
 # Returns client
@@ -289,7 +289,7 @@ def get_client(config):
          'member_code': member_code,
          'subsystem_code': subsystem_code,
          'connection_type': conn_type},
-        headers={'Authorization': config["security_server"][0]["api_key"][0]["key"], 'accept': 'application/json'},
+        headers={'Authorization': config["security_server"][0]["api_key"], 'accept': 'application/json'},
         verify=False)
     client_json = json.loads(str(client.content, 'utf-8').strip())
     return client_json[0]
@@ -319,7 +319,7 @@ def auth_cert_registration_global_configuration_update_received(config):
         config["security_server"][0]["url"] + "/tokens/" + str(config["security_server"][0]['software_token_id']),
         None,
         headers={
-            'Authorization': config["security_server"][0]["api_key"][0]["key"],
+            'Authorization': config["security_server"][0]["api_key"],
             'accept': 'application/json'
         },
         verify=False

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -68,7 +68,7 @@ class BaseController(Controller):
         curl_cmd = "curl -X POST -u " + admin_credentials + " --silent " + \
                    security_server["api_key_url"] + " --data \'" + json.dumps(roles).replace('"', '\\"') + "\'" + \
                    " --header \'Content-Type: application/json\' -k"
-        cmd = 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i "{}" {}@{} "{}"'.format(
+        cmd = 'ssh -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i "{}" {}@{} "{}"'.format(
             ssh_key, ssh_user, self.security_server_address(security_server), curl_cmd
         )
         if os.path.isfile(ssh_key):

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -62,9 +62,9 @@ class BaseController(Controller):
     def create_api_key(self, roles_list, security_server):
         self.log_debug('Creating API key for security server: ' + security_server['name'])
         roles = list(roles_list)
-        admin_credentials = security_server["admin_credentials"] if security_server["admin_credentials"] else self.config["admin_credentials"]
-        ssh_key = security_server["ssh_private_key"] if security_server["ssh_private_key"] else self.config["ssh_access"]["private_key"]
-        ssh_user = security_server["ssh_user"] if security_server["ssh_user"] else self.config["ssh_access"]["user"]
+        admin_credentials = security_server["admin_credentials"] if security_server.get("admin_credentials", "") else self.config["admin_credentials"]
+        ssh_key = security_server["ssh_private_key"] if security_server.get("ssh_private_key", "") else self.config["ssh_access"]["private_key"]
+        ssh_user = security_server["ssh_user"] if security_server.get("ssh_user", "") else self.config["ssh_access"]["user"]
         curl_cmd = "curl -X POST -u " + admin_credentials + " --silent " + \
                    security_server["api_key_url"] + " --data \'" + json.dumps(roles).replace('"', '\\"') + "\'" + \
                    " --header \'Content-Type: application/json\' -k"

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -23,7 +23,7 @@ from urllib.parse import urlparse
 from definitions import ROOT_DIR
 from xrdsst.core.conf_keys import validate_conf_keys, ConfKeysSecurityServer, ConfKeysRoot
 from xrdsst.core.excplanation import Excplanatory
-from xrdsst.core.util import op_node_to_ctr_cmd_text, RE_API_KEY_HEADER
+from xrdsst.core.util import op_node_to_ctr_cmd_text, RE_API_KEY_HEADER, get_admin_credentials, get_ssh_key, get_ssh_user
 from xrdsst.core.version import get_version
 from xrdsst.resources.texts import texts
 from xrdsst.configuration.configuration import Configuration
@@ -62,9 +62,9 @@ class BaseController(Controller):
     def create_api_key(self, roles_list, security_server):
         self.log_debug('Creating API key for security server: ' + security_server['name'])
         roles = list(roles_list)
-        admin_credentials = security_server["admin_credentials"] if security_server.get("admin_credentials", "") else self.config["admin_credentials"]
-        ssh_key = security_server["ssh_private_key"] if security_server.get("ssh_private_key", "") else self.config["ssh_access"]["private_key"]
-        ssh_user = security_server["ssh_user"] if security_server.get("ssh_user", "") else self.config["ssh_access"]["user"]
+        admin_credentials = get_admin_credentials(security_server, self.config)
+        ssh_key = get_ssh_key(security_server, self.config)
+        ssh_user = get_ssh_user(security_server, self.config)
         curl_cmd = "curl -X POST -u " + admin_credentials + " --silent " + \
                    security_server["api_key_url"] + " --data \'" + json.dumps(roles).replace('"', '\\"') + "\'" + \
                    " --header \'Content-Type: application/json\' -k"

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -62,7 +62,7 @@ class BaseController(Controller):
     def create_api_key(self, roles_list, security_server):
         self.log_debug('Creating API key for security server: ' + security_server['name'])
         roles = list(roles_list)
-        admin_credentials = security_server["admin_credentials"] if security_server["admin_credentials"] else self.config["ssh_access"]["admin_credentials"]
+        admin_credentials = security_server["admin_credentials"] if security_server["admin_credentials"] else self.config["admin_credentials"]
         ssh_key = security_server["ssh_private_key"] if security_server["ssh_private_key"] else self.config["ssh_access"]["private_key"]
         ssh_user = security_server["ssh_user"] if security_server["ssh_user"] else self.config["ssh_access"]["user"]
         curl_cmd = "curl -X POST -u " + admin_credentials + " --silent " + \
@@ -81,7 +81,8 @@ class BaseController(Controller):
                                   ' created.')
                     return api_key_json["key"]
                 else:
-                    self.log_api_error('API key creation for security server ' + security_server['name'] + ' failed.')
+                    self.log_api_error('BaseController->create_api_key:', 'API key creation for security server ' \
+                                       + security_server['name'] + ' failed (exit_code =' + str(exitcode) + ', data =' + str(data))
             except Exception as err:
                 self.log_api_error('BaseController->create_api_key:', err)
         else:

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from definitions import ROOT_DIR
-from xrdsst.core.conf_keys import validate_conf_keys, ConfKeysSecurityServer, ConfKeysRoot, ConfKeysSecServerApiKey
+from xrdsst.core.conf_keys import validate_conf_keys, ConfKeysSecurityServer, ConfKeysRoot
 from xrdsst.core.excplanation import Excplanatory
 from xrdsst.core.util import op_node_to_ctr_cmd_text, RE_API_KEY_HEADER
 from xrdsst.core.version import get_version
@@ -62,13 +62,16 @@ class BaseController(Controller):
     def create_api_key(self, roles_list, security_server):
         self.log_debug('Creating API key for security server: ' + security_server['name'])
         roles = list(roles_list)
-        curl_cmd = "curl -X POST -u " + security_server["api_key"][0]["credentials"] + " --silent " + \
-                   security_server["api_key"][0]["url"] + " --data \'" + json.dumps(roles).replace('"', '\\"') + "\'" + \
+        admin_credentials = security_server["admin_credentials"] if security_server["admin_credentials"] else self.config["ssh_access"]["admin_credentials"]
+        ssh_key = security_server["ssh_private_key"] if security_server["ssh_private_key"] else self.config["ssh_access"]["private_key"]
+        ssh_user = security_server["ssh_user"] if security_server["ssh_user"] else self.config["ssh_access"]["user"]
+        curl_cmd = "curl -X POST -u " + admin_credentials + " --silent " + \
+                   security_server["api_key_url"] + " --data \'" + json.dumps(roles).replace('"', '\\"') + "\'" + \
                    " --header \'Content-Type: application/json\' -k"
         cmd = 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i "{}" {}@{} "{}"'.format(
-            security_server["api_key"][0]["ssh_key"], security_server["api_key"][0]["ssh_user"], self.security_server_address(security_server), curl_cmd
+            ssh_key, ssh_user, self.security_server_address(security_server), curl_cmd
         )
-        if os.path.isfile(security_server["api_key"][0]["ssh_key"]):
+        if os.path.isfile(ssh_key):
             try:
                 exitcode, data = subprocess.getstatusoutput(cmd)
                 if exitcode == 0:
@@ -208,7 +211,7 @@ class BaseController(Controller):
 
     def get_api_key(self, conf, security_server):
         # Use API key configured for security server, if valid.
-        ss_api_key = security_server.get(ConfKeysSecurityServer.CONF_KEY_API_KEY)[0].get(ConfKeysSecServerApiKey.CONF_KEY_SS_API_KEY_KEY)
+        ss_api_key = security_server.get(ConfKeysSecurityServer.CONF_KEY_API_KEY)
         has_valid_ss_api_key = RE_API_KEY_HEADER.fullmatch(ss_api_key)
         if has_valid_ss_api_key:
             self.log_debug("Using existing API key for security server: '" + security_server['name'] + "'")
@@ -220,10 +223,9 @@ class BaseController(Controller):
 
         # Fallback attempt to create the (temporary) API key, if there seems to be SSH access configured.
         api_key = None
-        config = conf if conf else self.config
 
         if security_server.get(ConfKeysSecurityServer.CONF_KEY_API_KEY):
-            roles_list = security_server.get(ConfKeysSecurityServer.CONF_KEY_API_KEY)[0].get(ConfKeysSecServerApiKey.CONF_KEY_SS_API_KEY_ROLES)
+            roles_list = security_server.get(ConfKeysSecurityServer.CONF_KEY_API_KEY_ROLES)
             try:
                 api_key = 'X-Road-apikey token=' + self.create_api_key(roles_list, security_server)
                 self.app.api_keys[security_server[ConfKeysSecurityServer.CONF_KEY_NAME]] = api_key

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -59,12 +59,12 @@ class BaseController(Controller):
                                 metavar='file',
                                 default=os.path.join(ROOT_DIR, BaseController._DEFAULT_CONFIG_FILE))
 
-    def create_api_key(self, roles_list, security_server):
+    def create_api_key(self, config, roles_list, security_server):
         self.log_debug('Creating API key for security server: ' + security_server['name'])
         roles = list(roles_list)
-        admin_credentials = get_admin_credentials(security_server, self.config)
-        ssh_key = get_ssh_key(security_server, self.config)
-        ssh_user = get_ssh_user(security_server, self.config)
+        admin_credentials = get_admin_credentials(security_server, config)
+        ssh_key = get_ssh_key(security_server, config)
+        ssh_user = get_ssh_user(security_server, config)
         curl_cmd = "curl -X POST -u " + admin_credentials + " --silent " + \
                    security_server["api_key_url"] + " --data \'" + json.dumps(roles).replace('"', '\\"') + "\'" + \
                    " --header \'Content-Type: application/json\' -k"
@@ -224,11 +224,12 @@ class BaseController(Controller):
 
         # Fallback attempt to create the (temporary) API key, if there seems to be SSH access configured.
         api_key = None
+        config = conf if conf else self.config
 
         if security_server.get(ConfKeysSecurityServer.CONF_KEY_API_KEY):
-            roles_list = security_server.get(ConfKeysSecurityServer.CONF_KEY_API_KEY_ROLES)
+            roles_list = config.get(ConfKeysRoot.CONF_KEY_ROOT_API_KEY_ROLES)
             try:
-                api_key = 'X-Road-apikey token=' + self.create_api_key(roles_list, security_server)
+                api_key = 'X-Road-apikey token=' + self.create_api_key(config, roles_list, security_server)
                 self.app.api_keys[security_server[ConfKeysSecurityServer.CONF_KEY_NAME]] = api_key
             except Exception as err:
                 self.log_api_error('BaseController->get_api_key:', err)

--- a/xrdsst/core/conf_keys.py
+++ b/xrdsst/core/conf_keys.py
@@ -34,7 +34,6 @@ def validate_conf_keys(xrdsst_conf):
 
 # Known keys for xrdsst configuration file root.
 class ConfKeysRoot:
-    CONF_KEY_ROOT_API_KEY = 'api_key'
     CONF_KEY_ROOT_SERVER = 'security_server'
     CONF_KEY_ROOT_LOGGING = 'logging'
 
@@ -42,22 +41,9 @@ class ConfKeysRoot:
     @staticmethod
     def descendant_conf_keys():
         return [
-            (ConfKeysRoot.CONF_KEY_ROOT_API_KEY, ConfKeysApiKey),
             (ConfKeysRoot.CONF_KEY_ROOT_SERVER, ConfKeysSecurityServer),
             (ConfKeysRoot.CONF_KEY_ROOT_LOGGING, ConfKeysLogging)
         ]
-
-
-# Known keys for xrdsst configuration file security server API key creation section.
-class ConfKeysApiKey:
-    CONF_KEY_API_KEY_CREDENTIALS = 'credentials'
-    CONF_KEY_API_KEY_KEY = 'key'
-    CONF_KEY_API_KEY_ROLES = 'roles'
-    CONF_KEY_API_KEY_URL = 'url'
-
-    @staticmethod
-    def descendant_conf_keys():
-        return []
 
 
 # Known keys for xrdsst configuration file logging section.
@@ -90,8 +76,22 @@ class ConfKeysSecurityServer:
     @staticmethod
     def descendant_conf_keys():
         return [
+            (ConfKeysSecurityServer.CONF_KEY_API_KEY, ConfKeysSecServerApiKey),
             (ConfKeysSecurityServer.CONF_KEY_CLIENTS, ConfKeysSecServerClients)
         ]
+
+
+class ConfKeysSecServerApiKey:
+    CONF_KEY_SS_API_KEY_KEY = 'key'
+    CONF_KEY_SS_API_KEY_CREDENTIALS = 'credentials'
+    CONF_KEY_SS_API_KEY_SSH_USER = 'ssh_user'
+    CONF_KEY_SS_API_KEY_SSH_KEY = 'ssh_key'
+    CONF_KEY_SS_API_KEY_ROLES = 'roles'
+    CONF_KEY_SS_API_KEY_URL = 'url'
+
+    @staticmethod
+    def descendant_conf_keys():
+        return []
 
 
 # Known keys for xrdsst configuration file security server client configuration section.

--- a/xrdsst/core/conf_keys.py
+++ b/xrdsst/core/conf_keys.py
@@ -36,6 +36,7 @@ def validate_conf_keys(xrdsst_conf):
 class ConfKeysRoot:
     CONF_KEY_ROOT_SERVER = 'security_server'
     CONF_KEY_ROOT_ADMIN_CREDENTIALS = 'admin_credentials'
+    CONF_KEY_ROOT_API_KEY_ROLES = 'api_key_roles'
     CONF_KEY_ROOT_SSH_ACCESS = 'ssh_access'
     CONF_KEY_ROOT_LOGGING = 'logging'
 
@@ -70,7 +71,6 @@ class ConfKeysSSHAccess:
 class ConfKeysSecurityServer:
     CONF_KEY_ANCHOR = 'configuration_anchor'
     CONF_KEY_API_KEY = 'api_key'
-    CONF_KEY_API_KEY_ROLES = 'api_key_roles'
     CONF_KEY_API_KEY_URL = 'api_key_url'
     CONF_KEY_ADMIN_CREDENTIALS = 'admin_credentials'
     CONF_KEY_CERTS = 'certificates'

--- a/xrdsst/core/conf_keys.py
+++ b/xrdsst/core/conf_keys.py
@@ -35,6 +35,7 @@ def validate_conf_keys(xrdsst_conf):
 # Known keys for xrdsst configuration file root.
 class ConfKeysRoot:
     CONF_KEY_ROOT_SERVER = 'security_server'
+    CONF_KEY_ROOT_SSH_ACCESS = 'ssh_access'
     CONF_KEY_ROOT_LOGGING = 'logging'
 
     # Return the tuples ('child key', child conf keys class) for keys with descendants of their own
@@ -42,6 +43,7 @@ class ConfKeysRoot:
     def descendant_conf_keys():
         return [
             (ConfKeysRoot.CONF_KEY_ROOT_SERVER, ConfKeysSecurityServer),
+            (ConfKeysRoot.CONF_KEY_ROOT_SSH_ACCESS, ConfKeysSSHAccess),
             (ConfKeysRoot.CONF_KEY_ROOT_LOGGING, ConfKeysLogging)
         ]
 
@@ -55,11 +57,22 @@ class ConfKeysLogging:
     def descendant_conf_keys():
         return []
 
+class ConfKeysSSHAccess:
+    CONF_KEY_ADMIN_CREDENTIALS = 'admin_credentials'
+    CONF_KEY_USER = 'user'
+    CONF_KEY_PRIVATE_KEY = 'private_key'
+
+    @staticmethod
+    def descendant_conf_keys():
+        return []
 
 # Known keys for xrdsst configuration file security server configuration section.
 class ConfKeysSecurityServer:
     CONF_KEY_ANCHOR = 'configuration_anchor'
     CONF_KEY_API_KEY = 'api_key'
+    CONF_KEY_API_KEY_ROLES = 'api_key_roles'
+    CONF_KEY_API_KEY_URL = 'api_key_url'
+    CONF_KEY_ADMIN_CREDENTIALS = 'admin_credentials'
     CONF_KEY_CERTS = 'certificates'
     CONF_KEY_CLIENTS = 'clients'
     CONF_KEY_DN_C = 'owner_dn_country'
@@ -72,26 +85,14 @@ class ConfKeysSecurityServer:
     CONF_KEY_SOFT_TOKEN_PIN = 'software_token_pin'
     CONF_KEY_URL = 'url'
     CONF_KEY_FQDN = 'fqdn'
+    CONF_KEY_SSH_USER = 'ssh_user'
+    CONF_KEY_SSH_PRIVATE_KEY = 'ssh_private_key'
 
     @staticmethod
     def descendant_conf_keys():
         return [
-            (ConfKeysSecurityServer.CONF_KEY_API_KEY, ConfKeysSecServerApiKey),
             (ConfKeysSecurityServer.CONF_KEY_CLIENTS, ConfKeysSecServerClients)
         ]
-
-
-class ConfKeysSecServerApiKey:
-    CONF_KEY_SS_API_KEY_KEY = 'key'
-    CONF_KEY_SS_API_KEY_CREDENTIALS = 'credentials'
-    CONF_KEY_SS_API_KEY_SSH_USER = 'ssh_user'
-    CONF_KEY_SS_API_KEY_SSH_KEY = 'ssh_key'
-    CONF_KEY_SS_API_KEY_ROLES = 'roles'
-    CONF_KEY_SS_API_KEY_URL = 'url'
-
-    @staticmethod
-    def descendant_conf_keys():
-        return []
 
 
 # Known keys for xrdsst configuration file security server client configuration section.

--- a/xrdsst/core/conf_keys.py
+++ b/xrdsst/core/conf_keys.py
@@ -35,6 +35,7 @@ def validate_conf_keys(xrdsst_conf):
 # Known keys for xrdsst configuration file root.
 class ConfKeysRoot:
     CONF_KEY_ROOT_SERVER = 'security_server'
+    CONF_KEY_ROOT_ADMIN_CREDENTIALS = 'admin_credentials'
     CONF_KEY_ROOT_SSH_ACCESS = 'ssh_access'
     CONF_KEY_ROOT_LOGGING = 'logging'
 
@@ -58,7 +59,6 @@ class ConfKeysLogging:
         return []
 
 class ConfKeysSSHAccess:
-    CONF_KEY_ADMIN_CREDENTIALS = 'admin_credentials'
     CONF_KEY_USER = 'user'
     CONF_KEY_PRIVATE_KEY = 'private_key'
 

--- a/xrdsst/core/util.py
+++ b/xrdsst/core/util.py
@@ -111,7 +111,7 @@ def revoke_api_key(app):
                 logging.debug('Revoking API key for security server ' + ssn)
                 for security_server in config["security_server"]:
                     if ssn == security_server["name"]:
-                        credentials = security_server["admin_credentials"] if security_server["admin_credentials"] else config["ssh_access"]["admin_credentials"]
+                        credentials = security_server["admin_credentials"] if security_server["admin_credentials"] else config["admin_credentials"]
                         url = security_server["api_key_url"]
                         ssh_key = security_server["ssh_private_key"] if security_server["ssh_private_key"] else config["ssh_access"]["private_key"]
                         ssh_user = security_server["ssh_user"] if security_server["ssh_user"] else config["ssh_access"]["user"]

--- a/xrdsst/core/util.py
+++ b/xrdsst/core/util.py
@@ -111,10 +111,10 @@ def revoke_api_key(app):
                 logging.debug('Revoking API key for security server ' + ssn)
                 for security_server in config["security_server"]:
                     if ssn == security_server["name"]:
-                        credentials = security_server["api_key"][0]["credentials"]
-                        url = security_server["api_key"][0]["url"]
-                        ssh_key = security_server["api_key"][0]["ssh_key"]
-                        ssh_user = security_server["api_key"][0]["ssh_user"]
+                        credentials = security_server["admin_credentials"] if security_server["admin_credentials"] else config["ssh_access"]["admin_credentials"]
+                        url = security_server["api_key_url"]
+                        ssh_key = security_server["ssh_private_key"] if security_server["ssh_private_key"] else config["ssh_access"]["private_key"]
+                        ssh_user = security_server["ssh_user"] if security_server["ssh_user"] else config["ssh_access"]["user"]
                         curl_cmd = "curl -X DELETE -u " + credentials + " --silent " + url + "/" + str(api_key_id[ssn][0]) + " -k"
                         cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
                               ssh_key + "\" " + ssh_user + "@" + api_key_id[ssn][1] + " \"" + curl_cmd + "\""

--- a/xrdsst/core/util.py
+++ b/xrdsst/core/util.py
@@ -111,10 +111,10 @@ def revoke_api_key(app):
                 logging.debug('Revoking API key for security server ' + ssn)
                 for security_server in config["security_server"]:
                     if ssn == security_server["name"]:
-                        credentials = security_server["admin_credentials"] if security_server["admin_credentials"] else config["admin_credentials"]
+                        credentials = security_server["admin_credentials"] if security_server.get("admin_credentials", "") else config["admin_credentials"]
+                        ssh_key = security_server["ssh_private_key"] if security_server.get("ssh_private_key", "") else config["ssh_access"]["private_key"]
+                        ssh_user = security_server["ssh_user"] if security_server.get("ssh_user", "") else config["ssh_access"]["user"]
                         url = security_server["api_key_url"]
-                        ssh_key = security_server["ssh_private_key"] if security_server["ssh_private_key"] else config["ssh_access"]["private_key"]
-                        ssh_user = security_server["ssh_user"] if security_server["ssh_user"] else config["ssh_access"]["user"]
                         curl_cmd = "curl -X DELETE -u " + credentials + " --silent " + url + "/" + str(api_key_id[ssn][0]) + " -k"
                         cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
                               ssh_key + "\" " + ssh_user + "@" + api_key_id[ssn][1] + " \"" + curl_cmd + "\""

--- a/xrdsst/core/util.py
+++ b/xrdsst/core/util.py
@@ -127,7 +127,7 @@ def revoke_api_key(app):
                         ssh_user = get_ssh_user(security_server, config)
                         url = security_server["api_key_url"]
                         curl_cmd = "curl -X DELETE -u " + credentials + " --silent " + url + "/" + str(api_key_id[ssn][0]) + " -k"
-                        cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
+                        cmd = "ssh -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
                               ssh_key + "\" " + ssh_user + "@" + api_key_id[ssn][1] + " \"" + curl_cmd + "\""
                         exitcode, data = subprocess.getstatusoutput(cmd)
                         api_key_token = app.api_keys[ssn].split('=')[1]

--- a/xrdsst/core/util.py
+++ b/xrdsst/core/util.py
@@ -17,6 +17,17 @@ RE_API_KEY_HEADER = re.compile(r"""
     $
 """, re.VERBOSE | re.IGNORECASE)
 
+def get_admin_credentials(security_server, config):
+    admin_credentials = security_server["admin_credentials"] if security_server.get("admin_credentials", "") else config["admin_credentials"]
+    return admin_credentials
+
+def get_ssh_key(security_server, config):
+    ssh_key = security_server["ssh_private_key"] if security_server.get("ssh_private_key", "") else config["ssh_access"]["private_key"]
+    return ssh_key
+
+def get_ssh_user(security_server, config):
+    ssh_user = security_server["ssh_user"] if security_server.get("ssh_user", "") else config["ssh_access"]["user"]
+    return ssh_user
 
 # Returns toolkit default AUTHENTICATION key label, given security server configuration
 def default_auth_key_label(security_server):
@@ -111,9 +122,9 @@ def revoke_api_key(app):
                 logging.debug('Revoking API key for security server ' + ssn)
                 for security_server in config["security_server"]:
                     if ssn == security_server["name"]:
-                        credentials = security_server["admin_credentials"] if security_server.get("admin_credentials", "") else config["admin_credentials"]
-                        ssh_key = security_server["ssh_private_key"] if security_server.get("ssh_private_key", "") else config["ssh_access"]["private_key"]
-                        ssh_user = security_server["ssh_user"] if security_server.get("ssh_user", "") else config["ssh_access"]["user"]
+                        credentials = get_admin_credentials(security_server, config)
+                        ssh_key = get_ssh_key(security_server, config)
+                        ssh_user = get_ssh_user(security_server, config)
                         url = security_server["api_key_url"]
                         curl_cmd = "curl -X DELETE -u " + credentials + " --silent " + url + "/" + str(api_key_id[ssn][0]) + " -k"
                         cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \

--- a/xrdsst/core/util.py
+++ b/xrdsst/core/util.py
@@ -1,5 +1,9 @@
+import logging
 import os
 import re
+import subprocess
+
+import yaml
 
 # Regex of X-Road security server header for API key.
 RE_API_KEY_HEADER = re.compile(r"""
@@ -92,3 +96,36 @@ def is_ss_connectable(ss_url, sock_timeout=1):
         return True, ''
     except error as err:
         return False, os.strerror(err.errno) if err.errno else str(err)
+
+
+def revoke_api_key(app):
+    if len(app.argv) > 1:
+        api_key_id = app.Meta.handlers[0].api_key_id
+        if api_key_id:
+            config_file = app.pargs.configfile if app.pargs.configfile else app.Meta.handlers[0].config_file
+            if not os.path.exists(config_file):
+                config_file = os.path.join("..", config_file)
+            with open(config_file, "r") as yml_file:
+                config = yaml.safe_load(yml_file)
+            for ssn in api_key_id.keys():
+                logging.debug('Revoking API key for security server ' + ssn)
+                for security_server in config["security_server"]:
+                    if ssn == security_server["name"]:
+                        credentials = security_server["api_key"][0]["credentials"]
+                        url = security_server["api_key"][0]["url"]
+                        ssh_key = security_server["api_key"][0]["ssh_key"]
+                        ssh_user = security_server["api_key"][0]["ssh_user"]
+                        curl_cmd = "curl -X DELETE -u " + credentials + " --silent " + url + "/" + str(api_key_id[ssn][0]) + " -k"
+                        cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
+                              ssh_key + "\" " + ssh_user + "@" + api_key_id[ssn][1] + " \"" + curl_cmd + "\""
+                        exitcode, data = subprocess.getstatusoutput(cmd)
+                        api_key_token = app.api_keys[ssn].split('=')[1]
+                        if exitcode == 0:
+                            log_info("API key '" + api_key_token + "' for security server " + ssn + " revoked.")
+                        else:
+                            logging.warning("Revocation of API key '" + api_key_token + "' for security server ' + ssn + ' failed")
+
+
+def log_info(message):
+    logging.info(message)
+    print(message)

--- a/xrdsst/core/validator.py
+++ b/xrdsst/core/validator.py
@@ -3,8 +3,7 @@ import os
 
 import cement.utils.fs
 
-from xrdsst.core.conf_keys import ConfKeysSecurityServer, ConfKeysSecServerClients, ConfKeysSecServerClientServiceDesc, \
-    ConfKeysSecServerClientServiceDescService
+from xrdsst.core.conf_keys import ConfKeysSecurityServer, ConfKeysSecServerClients, ConfKeysSecServerClientServiceDesc
 from xrdsst.core.util import convert_swagger_enum
 from xrdsst.models import ConnectionType, ServiceType
 
@@ -306,7 +305,6 @@ def validate_config_service_desc_service(ss_config, operation, errors):
                 ConfKeysSecServerClientServiceDesc.CONF_KEY_SS_CLIENT_SERVICE_DESC_URL,
                 service_desc_config[service_desc_ix], operation, errors)
 
-
             require_fill(
                 ConfKeysSecServerClientServiceDesc.CONF_KEY_SS_CLIENT_SERVICE_DESC_URL_ALL,
                 service_desc_config[service_desc_ix], operation, errors)
@@ -318,7 +316,6 @@ def validate_config_service_desc_service(ss_config, operation, errors):
             require_fill(
                 ConfKeysSecServerClientServiceDesc.CONF_KEY_SS_CLIENT_SERVICE_DESC_TIMEOUT_ALL,
                 service_desc_config[service_desc_ix], operation, errors)
-
 
             if ServiceType.REST == service_desc_config[service_desc_ix].get(ConfKeysSecServerClientServiceDesc.CONF_KEY_SS_CLIENT_SERVICE_DESC_TYPE):
                 require_fill(

--- a/xrdsst/core/version.py
+++ b/xrdsst/core/version.py
@@ -1,7 +1,7 @@
 """Module for getting project version"""
 from cement.utils.version import get_version as cement_get_version
 
-CURRENT_VERSION = "0.3.1-alpha.0"
+CURRENT_VERSION = "0.3.2-alpha.0"
 
 
 def convert_version(version_str):


### PR DESCRIPTION
Make SSH user for api key creation configurable from configuration file and move api_key section into security_server section in the configuration file.