### PR TITLE
Insensitive logs sstoolkit 66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.4.0-alpha.0] - 2021-03-30
+## [0.4.0-alpha.0] - 2021-04-05
 - Mask API key representations in log files.
+- Represent API key in configuration as UUID, without HTTP header prefix.
 
 ## [0.3.3-alpha.0] - 2021-04-05
 - remove undocumented configuration element ``api_key_roles``

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0-alpha.0] - 2021-03-30
+- Mask API key representations in log files.
+
 ## [0.3.3-alpha.0] - 2021-04-05
 - remove undocumented configuration element ``api_key_roles``
 - Stop toolkits' attempts to further communicate with security server when API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [0.4.0-alpha.0] - 2021-04-05
 - Mask API key representations in log files.
 - Represent API key in configuration as UUID, without HTTP header prefix.
+- init logging after config key-level validation, non-mutable ops undifferentiated.
 
 ## [0.3.3-alpha.0] - 2021-04-05
 - remove undocumented configuration element ``api_key_roles``

--- a/config/xrdsst.yml
+++ b/config/xrdsst.yml
@@ -3,7 +3,7 @@ ssh_access:
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
 security_server:
-- api_key: X-Road-apikey token=<API_KEY>
+- api_key: <API_KEY>
   api_key_url: https://localhost:4000/api/v1/api-keys
   admin_credentials:
   configuration_anchor: /path/to/configuration-anchor.xml

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -2,7 +2,7 @@
 
 **Technical Specification**
 
-Version: 1.2.7
+Version: 1.2.8
 Doc. ID: XRDSST-CONF
 
 ---
@@ -29,6 +29,7 @@ Doc. ID: XRDSST-CONF
 | 26.03.2021 | 1.2.5       | Add 'fqdn' key for security server, fix service field descriptions           | Taimo Peelo        |
 | 31.03.2021 | 1.2.6       | Refactorization of configuration file related to SSH and api key parameters  | Bert Viikmäe       |
 | 01.04.2021 | 1.2.7       | Describe backup use, clarify toolkits' error interpretation role, remove undocumented ``api_key_roles`` configuration element | Taimo Peelo        |
+| 05.04.2021 | 1.2.8       | Remove HTTP header value prefix from 'api_key' configuration element         | Taimo Peelo        |
 
 ## Table of Contents <!-- omit in toc -->
 
@@ -122,7 +123,7 @@ ssh_access:
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
 security_server:
-- api_key: X-Road-apikey token=<API_KEY>
+- api_key: <API_KEY>
   api_key_url: https://localhost:4000/api/v1/api-keys
   admin_credentials: <SECURITY_SERVER_CREDENTIALS>
   configuration_anchor: /path/to/configuration-anchor.xml
@@ -177,8 +178,7 @@ The ``security_server`` section is for configuring security server parameters
   but if specified in the ``security_server`` section, the value will be overridden for specific configurable security server)  
 * ``/path/to/xrdsst.log`` should be substituted with the correct path to the log file, e.g. "/var/log/xroad/xrdsst.log"
 * <LOG_LEVEL> parameter for configuring the logging level for the X-Road Security Server Toolkit, e.g INFO
-* <API_KEY> if un-filled, a temporary api key will be automatically created and revoked in the end of a single operation, if filled with value in
-  the format of ``X-Road-apikey token=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx``, that key will be used and a temporary key will not be created
+* <API_KEY> filled with API key for security server or left as-is/any for toolkit to attempt creation of transient API key
 * ``/path/to/configuration-anchor.xml`` should be substituted with the correct path to the configuration anchor file, e.g. "/etc/xroad/configuration-anchor.xml"
 * <SECURITY_SERVER_NAME> should be substituted with the installed security server name, e.g. ss1
 * <OWNER_DISTINGUISHED_NAME_COUNTRY> should be ISO 3166-1 alpha-2 two letter code for server owner country. This is used in certificate generation.
@@ -411,7 +411,7 @@ line 32 below:
 ```yaml
 # ... SNIPPED
 security_server:                                                     # line 11
-- api_key: X-Road-apikey token=8d527381-80c1-4910-a259-7e3c23253397  # line 12
+- api_key: 8d527381-80c1-4910-a259-7e3c23253397                      # line 12
 # ... SNIPPED
   clients:                                                           # line 27
     - member_class: GOV                                              # line 28

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.3-alpha.0
+current_version = 0.4.0-alpha.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)\.(?P<build>\d+))?

--- a/tests/integration/integration_base.py
+++ b/tests/integration/integration_base.py
@@ -39,7 +39,7 @@ class IntegrationTestBase(unittest.TestCase):
                 [{'name': 'ss',
                   'url': 'https://CONTAINER_HOST:4000/api/v1',
                   'fqdn': 'client_only',
-                  'api_key': 'X-Road-apikey token=a2e9dea1-de53-4ebc-a750-6be6461d91f0',
+                  'api_key': 'a2e9dea1-de53-4ebc-a750-6be6461d91f0',
                   'api_key_url': self.url,
                   'configuration_anchor': os.path.join(ROOT_DIR, self.configuration_anchor),
                   'owner_dn_country': 'FI',
@@ -83,7 +83,7 @@ class IntegrationTestBase(unittest.TestCase):
         return self.config
 
     def set_api_key(self, api_key):
-        self.config["security_server"][0]["api_key"] = 'X-Road-apikey token=' + api_key
+        self.config["security_server"][0]["api_key"] = api_key
 
     def set_ip_url(self, ip_address):
         local_url = self.config["security_server"][0]["url"]

--- a/tests/resources/test-config-template.yaml
+++ b/tests/resources/test-config-template.yaml
@@ -3,7 +3,7 @@ ssh_access:
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
 security_server:
-- api_key: X-Road-apikey token=<API_KEY>
+- api_key: <API_KEY>
   api_key_url: https://localhost:4000/api/v1/api-keys
   admin_credentials:
   certificates:

--- a/tests/unit/test_auto.py
+++ b/tests/unit/test_auto.py
@@ -24,7 +24,7 @@ class TestAuto(unittest.TestCase):
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
-              'api_key': 'X-Road-apikey token=66666666-8000-4011-a000-333336633333',
+              'api_key': '66666666-8000-4011-a000-333336633333',
               'api_key_url': 'https://localhost:4000/api/v1/api-keys'
             }]}
 

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -289,7 +289,7 @@ class TestBaseController(unittest.TestCase):
 
         self._ss_config["logging"]["file"] = temp_file_name
         base_controller = BaseController()
-        base_controller.init_logging(self.get_ss_config())
+        base_controller._init_logging(self.get_ss_config())
         assert len(logging.getLogger().handlers) == 1
         assert os.path.exists(temp_file_name)
 
@@ -305,7 +305,7 @@ class TestBaseController(unittest.TestCase):
 
         self._ss_config["logging"]["file"] = temp_file_name
         base_controller = BaseController()
-        base_controller.init_logging(self.get_ss_config())
+        base_controller._init_logging(self.get_ss_config())
         assert len(logging.getLogger().handlers) == 1
 
     def test_init_logging_directory(self):
@@ -317,7 +317,7 @@ class TestBaseController(unittest.TestCase):
 
         self._ss_config["logging"]["file"] = temp_file_name
         base_controller = BaseController()
-        base_controller.init_logging(self.get_ss_config())
+        base_controller._init_logging(self.get_ss_config())
         assert len(logging.getLogger().handlers) == 1
 
     def test_no_plain_api_key_logging(self):
@@ -333,7 +333,7 @@ class TestBaseController(unittest.TestCase):
 
         self._ss_config["logging"]["file"] = logfile_name
         base_controller = BaseController()
-        base_controller.init_logging(self.get_ss_config())
+        base_controller._init_logging(self.get_ss_config())
 
         the_api_key = '460ad0b9-d023-4087-a291-dc97eddcb7d8'
 

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -27,7 +27,7 @@ class TestBaseController(unittest.TestCase):
         'security_server':
             [{'name': 'ss',
               'url': 'https://ss:4000/api/v1',
-              'api_key': 'X-Road-apikey token=f160830d-d75a-476e-a9ad-9c12abff00d3',
+              'api_key': 'f160830d-d75a-476e-a9ad-9c12abff00d3',
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'configuration_anchor': configuration_anchor,
               'owner_member_class': 'GOV',
@@ -360,13 +360,13 @@ class TestBaseController(unittest.TestCase):
                 temp_file_name = os.path.join(ROOT_DIR, "conf.yaml")
                 config = self.create_temp_conf(base_controller, temp_file_name)
                 security_server = config["security_server"][0]
-                security_server["api_key"] = 'X-Road-apikey token=some key'
+                security_server["api_key"] = 'some key'
                 key = base_controller.get_api_key(config, security_server)
-                assert key != 'X-Road-apikey token=api-key-123'
-                security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'
+                assert key != 'api-key-123'
+                security_server["api_key"] = '<API_KEY>'
                 key = base_controller.get_api_key(config, security_server)
                 os.remove(temp_file_name)
-                assert key == 'X-Road-apikey token=88888888-8000-4000-a000-727272727272'
+                assert key == '88888888-8000-4000-a000-727272727272'
 
     def test_get_api_key_ssh_key_exception(self):
         with XRDSSTTest() as app:
@@ -375,7 +375,7 @@ class TestBaseController(unittest.TestCase):
             temp_file_name = os.path.join(ROOT_DIR, "conf.yaml")
             config = self.create_temp_conf(base_controller, temp_file_name)
             security_server = config["security_server"][0]
-            security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'
+            security_server["api_key"] = '<API_KEY>'
             base_controller.get_api_key(config, security_server)
             os.remove(temp_file_name)
             self.assertRaises(Exception)
@@ -391,7 +391,7 @@ class TestBaseController(unittest.TestCase):
             ssh_access = config["ssh_access"]
             security_server = config["security_server"][0]
             ssh_access["private_key"] = 'my_key'
-            security_server["api_key"] = 'X-Road-apikey token=<API_KEY>'
+            security_server["api_key"] = '<API_KEY>'
             base_controller.get_api_key(config, security_server)
             os.remove(temp_file_name)
             os.remove("my_key")

--- a/tests/unit/test_cert.py
+++ b/tests/unit/test_cert.py
@@ -253,7 +253,7 @@ class TestCert(unittest.TestCase):
                   '/some/where/authcert',
                   '/some/where/signcert',
               ],
-              'api_key': 'X-Road-apikey token=88888888-8000-4000-a000-727272727272',
+              'api_key': '88888888-8000-4000-a000-727272727272',
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'owner_dn_country': 'FI',
               'owner_dn_org': 'UNSERE',

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -36,7 +36,7 @@ class TestClient(unittest.TestCase):
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
-              'api_key': 'X-Road-apikey token=55555555-5000-4000-a000-707070707070',
+              'api_key': '55555555-5000-4000-a000-707070707070',
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'clients': [
                   {

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -38,7 +38,7 @@ class TestInit(unittest.TestCase):
         'security_server':
             [{'name': 'ss',
               'url': 'https://no.there.com:4000/api/v1',
-              'api_key': 'X-Road-apikey token=<API_KEY>',
+              'api_key': '<API_KEY>',
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'configuration_anchor': configuration_anchor,
               'owner_member_class': 'GOV',

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -41,7 +41,7 @@ class TestService(unittest.TestCase):
         'security_server':
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
-              'api_key': 'X-Road-apikey token=33333333-3000-4000-b000-939393939393',
+              'api_key': '33333333-3000-4000-b000-939393939393',
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'clients': [
                   {

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -34,7 +34,7 @@ class TestStatus(unittest.TestCase):
                   '/some/where/authcert',
                   '/some/where/signcert',
               ],
-              'api_key': 'X-Road-apikey token=86668888-8000-4000-a000-277727227272',
+              'api_key': '86668888-8000-4000-a000-277727227272',
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'owner_dn_country': 'FI',
               'owner_dn_org': 'UNSERE',

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -157,7 +157,7 @@ class TestToken(unittest.TestCase):
             [{'name': 'ssX',
               'url': 'https://non.existing.url.blah:8999/api/v1',
               'fqdn': 'client_only',
-              'api_key': 'X-Road-apikey token=86668888-8000-4000-a000-277727227272',
+              'api_key': '86668888-8000-4000-a000-277727227272',
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'configuration_anchor': configuration_anchor,
               'owner_dn_country': 'FI',

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -5,6 +5,8 @@ import time
 from datetime import datetime, timedelta
 from urllib.parse import urlparse
 import requests
+
+from xrdsst.controllers.base import BaseController
 from xrdsst.controllers.status import ServerStatus
 from xrdsst.core.api_util import StatusRoles, StatusVersion, StatusGlobal, StatusServerInitialization, \
     StatusServerTimestamping, StatusToken, StatusKeys, StatusCsrs, StatusCerts
@@ -252,7 +254,7 @@ def api_GET(api_url, api_path, api_key):
     full_url = api_url + "/" + api_path
     response = requests.get(
         full_url,
-        headers={'Authorization': api_key, 'accept': 'application/json'},
+        headers={'Authorization': BaseController.authorization_header(api_key), 'accept': 'application/json'},
         verify=False)
 
     if response.status_code != 200:
@@ -289,7 +291,7 @@ def get_client(config):
          'member_code': member_code,
          'subsystem_code': subsystem_code,
          'connection_type': conn_type},
-        headers={'Authorization': config["security_server"][0]["api_key"], 'accept': 'application/json'},
+        headers={'Authorization': BaseController.authorization_header(config["security_server"][0]["api_key"]), 'accept': 'application/json'},
         verify=False)
     client_json = json.loads(str(client.content, 'utf-8').strip())
     return client_json[0]
@@ -319,7 +321,7 @@ def auth_cert_registration_global_configuration_update_received(config):
         config["security_server"][0]["url"] + "/tokens/" + str(config["security_server"][0]['software_token_id']),
         None,
         headers={
-            'Authorization': config["security_server"][0]["api_key"],
+            'Authorization': BaseController.authorization_header(config["security_server"][0]["api_key"]),
             'accept': 'application/json'
         },
         verify=False

--- a/xrdsst/controllers/auto.py
+++ b/xrdsst/controllers/auto.py
@@ -21,7 +21,6 @@ class AutoController(BaseController):
         self._auto(active_config)
 
     def _auto(self, active_config):
-        self.init_logging(active_config)
         all_server_config = copy.deepcopy(active_config)
         for i in range(0, len(all_server_config[ConfKeysRoot.CONF_KEY_ROOT_SERVER])):
             single_server_config = all_server_config[ConfKeysRoot.CONF_KEY_ROOT_SERVER][i:(i+1)]

--- a/xrdsst/controllers/cert.py
+++ b/xrdsst/controllers/cert.py
@@ -99,7 +99,6 @@ class CertController(BaseController):
         return self._download_csrs(active_config)
 
     def import_certificates(self, config):
-        self.init_logging(config)
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 
         for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
@@ -109,7 +108,6 @@ class CertController(BaseController):
         BaseController.log_keyless_servers(ss_api_conf_tuple)
 
     def register_certificate(self, config):
-        self.init_logging(config)
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 
         for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
@@ -119,7 +117,6 @@ class CertController(BaseController):
         BaseController.log_keyless_servers(ss_api_conf_tuple)
 
     def activate_certificate(self, config):
-        self.init_logging(config)
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 
         for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
@@ -129,7 +126,6 @@ class CertController(BaseController):
         BaseController.log_keyless_servers(ss_api_conf_tuple)
 
     def _download_csrs(self, config):
-        self.init_logging(config)
         downloaded_csrs = []
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 

--- a/xrdsst/controllers/client.py
+++ b/xrdsst/controllers/client.py
@@ -46,7 +46,6 @@ class ClientController(BaseController):
 
     # This operation can (at least sometimes) also be performed when global status is FAIL.
     def add_client(self, config):
-        self.init_logging(config)
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 
         for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
@@ -59,7 +58,6 @@ class ClientController(BaseController):
 
     # This operation fails when global status is not up to date.
     def register_client(self, config):
-        self.init_logging(config)
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 
         for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:

--- a/xrdsst/controllers/init.py
+++ b/xrdsst/controllers/init.py
@@ -30,7 +30,6 @@ class InitServerController(BaseController):
         self.initialize_server(active_config)
 
     def initialize_server(self, config):
-        self.init_logging(config)
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 
         for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:

--- a/xrdsst/controllers/service.py
+++ b/xrdsst/controllers/service.py
@@ -72,7 +72,6 @@ class ServiceController(BaseController):
         self.update_service_parameters(active_config)
 
     def add_service_description(self, config):
-        self.init_logging(config)
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 
         for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
@@ -86,7 +85,6 @@ class ServiceController(BaseController):
         BaseController.log_keyless_servers(ss_api_conf_tuple)
 
     def enable_service_description(self, config):
-        self.init_logging(config)
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 
         for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
@@ -100,7 +98,6 @@ class ServiceController(BaseController):
         BaseController.log_keyless_servers(ss_api_conf_tuple)
 
     def add_access_rights(self, config):
-        self.init_logging(config)
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 
         for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
@@ -114,7 +111,6 @@ class ServiceController(BaseController):
         BaseController.log_keyless_servers(ss_api_conf_tuple)
 
     def update_service_parameters(self, config):
-        self.init_logging(config)
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 
         for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:

--- a/xrdsst/controllers/status.py
+++ b/xrdsst/controllers/status.py
@@ -111,7 +111,6 @@ class StatusController(BaseController):
     def _default(self):
         return self._status(self.load_config())  # Returned for status comparisons in tests only
 
-    # Since this is read-only operation, do not log anything, only console output
     def _status(self, config):
         render_data = []
         servers = []

--- a/xrdsst/controllers/timestamp.py
+++ b/xrdsst/controllers/timestamp.py
@@ -65,7 +65,6 @@ class TimestampController(BaseController):
 
         self.timestamp_service_init(active_config)
 
-    # Since this is read-only operation, do not log anything, only console output
     def timestamp_service_list(self, config):
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 
@@ -120,8 +119,7 @@ class TimestampController(BaseController):
         except ApiException as e:
             print("Exception when listing timestamping services: %s\n", e)
 
-    def timestamp_service_init(self, config):  # logging required
-        self.init_logging(config)
+    def timestamp_service_init(self, config):
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 
         for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:

--- a/xrdsst/controllers/token.py
+++ b/xrdsst/controllers/token.py
@@ -76,13 +76,11 @@ class TokenController(BaseController):
         self.token_add_keys_with_csrs(active_config)
 
     def token_list(self, config):
-        self.init_logging(config)
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
         for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             self.remote_token_list(ss_api_config)
         BaseController.log_keyless_servers(ss_api_conf_tuple)
 
-    # Since this is read-only operation, do not log anything, only console output
     def remote_token_list(self, ss_api_config):
         try:
             token_api = TokensApi(ApiClient(ss_api_config))
@@ -108,7 +106,6 @@ class TokenController(BaseController):
             print("Exception when calling TokensApi->get_tokens: %s\n" % err)
 
     def token_login(self, config):
-        self.init_logging(config)
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 
         for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
@@ -136,7 +133,6 @@ class TokenController(BaseController):
                 BaseController.log_api_error('TokensApi->login_token', err)
 
     def token_add_keys_with_csrs(self, config):
-        self.init_logging(config)
         ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
 
         for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:

--- a/xrdsst/core/util.py
+++ b/xrdsst/core/util.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import re
 import subprocess
 
 import yaml

--- a/xrdsst/core/util.py
+++ b/xrdsst/core/util.py
@@ -5,18 +5,6 @@ import subprocess
 
 import yaml
 
-# Regex of X-Road security server header for API key.
-RE_API_KEY_HEADER = re.compile(r"""
-    ^
-    X-Road-apikey[ ]token=
-    [a-f0-9]{8}-
-    [a-f0-9]{4}-
-    [a-f0-9]{4}-  # Do not fix UUID version
-    [a-f0-9]{4}-  # Do no validate first character separately
-    [a-f0-9]{12}
-    $
-""", re.VERBOSE | re.IGNORECASE)
-
 def get_admin_credentials(security_server, config):
     admin_credentials = security_server["admin_credentials"] if security_server.get("admin_credentials", "") else config["admin_credentials"]
     return admin_credentials

--- a/xrdsst/core/util.py
+++ b/xrdsst/core/util.py
@@ -118,7 +118,7 @@ def revoke_api_key(app):
                         cmd = "ssh -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR -i \"" + \
                               ssh_key + "\" " + ssh_user + "@" + api_key_id[ssn][1] + " \"" + curl_cmd + "\""
                         exitcode, data = subprocess.getstatusoutput(cmd)
-                        api_key_token = app.api_keys[ssn].split('=')[1]
+                        api_key_token = app.api_keys[ssn]
                         if exitcode == 0:
                             log_info("API key '" + api_key_token + "' for security server " + ssn + " revoked.")
                         else:

--- a/xrdsst/core/version.py
+++ b/xrdsst/core/version.py
@@ -1,7 +1,7 @@
 """Module for getting project version"""
 from cement.utils.version import get_version as cement_get_version
 
-CURRENT_VERSION = "0.3.3-alpha.0"
+CURRENT_VERSION = "0.4.0-alpha.0"
 
 
 def convert_version(version_str):


### PR DESCRIPTION
Masks the API key representation in log files, revealing ~12 bits of entropy from original ~120 bits of entropy.

```
7b6b39d5-64a4-428b-a0b3-ed950acab9bf  # original
********-****-428b-****-************  # masked
```

Side-quests:

Restore the no-log-configured temporary log file creation behaviour for single operations, bisected to f28fd3bd9574c3acafc451aadd8012c7ea51bada borkage where ``init_logging(...)`` gets applied **after** first status queries, for which unconfigured API_KEY scenario invokes ``get_api_key(..) -> create_api_key(...)`` which logging attempts create StreamHandler with unset log level and then kept once-only application of init_logging() from occuring, since this activated only when /no/ log handlers existed yet.