### PR TITLE
Release todos p3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.3-alpha.0] - 2021-04-05
+- remove undocumented configuration element ``api_key_roles``
+- Stop toolkits' attempts to further communicate with security server when API
+  key unavailable or access denied.
+
 ## [0.3.2-alpha.0] - 2021-03-29
 - Make SSH user configurable for api key creation
 

--- a/config/xrdsst.yml
+++ b/config/xrdsst.yml
@@ -1,9 +1,4 @@
 admin_credentials: <SECURITY_SERVER_CREDENTIALS>
-api_key_roles:
-- XROAD_SYSTEM_ADMINISTRATOR
-- XROAD_SERVICE_ADMINISTRATOR
-- XROAD_SECURITY_OFFICER
-- XROAD_REGISTRATION_OFFICER
 ssh_access:
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key

--- a/docs/xroad_security_server_toolkit_user_guide.md
+++ b/docs/xroad_security_server_toolkit_user_guide.md
@@ -2,7 +2,7 @@
 
 **Technical Specification**
 
-Version: 1.2.6
+Version: 1.2.7
 Doc. ID: XRDSST-CONF
 
 ---
@@ -28,6 +28,7 @@ Doc. ID: XRDSST-CONF
 | 22.03.2021 | 1.2.4       | Default configuration from config/base.yaml -> config/xrdsst.yml             | Taimo Peelo        |
 | 26.03.2021 | 1.2.5       | Add 'fqdn' key for security server, fix service field descriptions           | Taimo Peelo        |
 | 31.03.2021 | 1.2.6       | Refactorization of configuration file related to SSH and api key parameters  | Bert Viikmäe       |
+| 01.04.2021 | 1.2.7       | Describe backup use, clarify toolkits' error interpretation role, remove undocumented ``api_key_roles`` configuration element | Taimo Peelo        |
 
 ## Table of Contents <!-- omit in toc -->
 
@@ -37,6 +38,7 @@ Doc. ID: XRDSST-CONF
 * [License](#license)
 * [1. Introduction](#1-introduction)
 	* [1.1 Target Audience](#11-target-audience)
+	* [1.2 References](#12-references)
 * [2. Installation](#2-installation)
 	* [2.1 Prerequisites to Installation](#21-prerequisites-to-installation)
 	* [2.2 Installation procedure](#22-installation-procedure)
@@ -61,6 +63,7 @@ Doc. ID: XRDSST-CONF
 		* [5.3.1 Malformed YAML](#531-malformed-yaml)
 		* [5.3.2 Other configuration file errors](#532-other-configuration-file-errors)
 	* [5.4 Errors from internal and external systems](#54-errors-from-internal-and-external-systems)
+	* [5.5 Recovery from misconfiguration](#55-recovery-from-misconfiguration)
 
 <!-- vim-markdown-toc -->
 <!-- tocstop -->
@@ -75,6 +78,10 @@ This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 
 
 The intended audience of this installation guide are the X-Road security server administrators responsible for installing and configuring the X-Road security server software.
 The document is intended for readers with a good knowledge of Linux server management, computer networks, and the X-Road functioning principles.
+
+### 1.2 References
+
+* <a id="Ref_SS-UG" class="anchor"></a> [\[UG-SS\] Security Server User Guide](https://docs.x-road.global/Manuals/ug-ss_x-road_6_security_server_user_guide.html)
 
 ## 2. Installation
 
@@ -111,11 +118,6 @@ $ pip install setup.py
 ### 3.2 Format of configuration file
 ```
 admin_credentials: <SECURITY_SERVER_CREDENTIALS>
-api_key_roles:
-- XROAD_SYSTEM_ADMINISTRATOR
-- XROAD_SERVICE_ADMINISTRATOR
-- XROAD_SECURITY_OFFICER
-- XROAD_REGISTRATION_OFFICER
 ssh_access:
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key
@@ -466,7 +468,7 @@ originates.
 Toolkit itself tries to point out the error source, CLIENT proxy errors happen straight
 at the configured server and can be often addressed immediately, but SERVER proxy 
 or Service PROVIDER errors will require reaching out externally. For client proxy errors
-that are more common, there are sometimes messages given about their possible causes and
+that are more common, toolkit offers additional messages about their possible causes and
 sometimes even hints of possible solutions. For server proxy errors, as much of the
 information is shown as acquired from SERVER proxy or service PROVIDER information
 system behind SERVER proxy:
@@ -501,3 +503,12 @@ sorted out inside organization, getting the services enabled again. In any case,
 the key to successfully resolving such situations is to pay careful attention
 to the error messages and accompanying ASCII diagram with message flow, to not
 spend time at searching for the problem in the wrong places.
+
+### 5.5 Recovery from misconfiguration
+This version of toolkit does not yet offer explicit support for backup and restore
+operations of the security server (scheduled for next release of the toolkit). In
+case something goes so wrong that way out or way back cannot be seen, it is possible
+to use nightly backups that are kept at security server to revert to earlier state.
+Overview of existing automatic backups is accessible from web administration console
+of the security server, in the "Settings" menu. More information about functionality
+can be found in [UG-SS](#Ref_SS-UG).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.2-alpha.0
+current_version = 0.3.3-alpha.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)\.(?P<build>\d+))?

--- a/tests/end_to_end/tests.py
+++ b/tests/end_to_end/tests.py
@@ -55,7 +55,7 @@ class EndToEndTest(unittest.TestCase):
     def step_init(self):
         init = InitServerController()
         for security_server in self.config["security_server"]:
-            configuration = init.initialize_basic_config_values(security_server, self.config)
+            configuration = init.create_api_config(security_server, self.config)
             status = init.check_init_status(configuration)
             assert status.is_anchor_imported is False and status.is_server_code_initialized is False
             init.initialize_server(self.config)
@@ -67,7 +67,7 @@ class EndToEndTest(unittest.TestCase):
             timestamp_controller = TimestampController()
             timestamp_controller.app = app
             for security_server in self.config["security_server"]:
-                configuration = timestamp_controller.initialize_basic_config_values(security_server, self.config)
+                configuration = timestamp_controller.create_api_config(security_server, self.config)
                 response = timestamp_controller.remote_get_configured(configuration)
                 assert response == []
                 timestamp_controller.remote_timestamp_service_init(configuration, security_server)
@@ -81,7 +81,7 @@ class EndToEndTest(unittest.TestCase):
             token_controller = TokenController()
             token_controller.app = app
             for security_server in self.config["security_server"]:
-                configuration = token_controller.initialize_basic_config_values(security_server, self.config)
+                configuration = token_controller.create_api_config(security_server, self.config)
                 response = token_controller.remote_get_tokens(configuration)
                 assert len(response) > 0
                 assert response[0].logged_in is False
@@ -95,7 +95,7 @@ class EndToEndTest(unittest.TestCase):
             token_controller = TokenController()
             token_controller.app = app
             for security_server in self.config["security_server"]:
-                configuration = token_controller.initialize_basic_config_values(security_server, self.config)
+                configuration = token_controller.create_api_config(security_server, self.config)
                 response = token_controller.remote_get_tokens(configuration)
                 assert len(response) > 0
                 assert len(response[0].keys) == 0
@@ -113,7 +113,7 @@ class EndToEndTest(unittest.TestCase):
             cert_controller = CertController()
             cert_controller.app = app
             for security_server in self.config["security_server"]:
-                ss_configuration = cert_controller.initialize_basic_config_values(security_server, self.config)
+                ss_configuration = cert_controller.create_api_config(security_server, self.config)
                 result = cert_controller.remote_download_csrs(ss_configuration, security_server)
                 assert len(result) == 2
                 assert result[0].fs_loc != result[1].fs_loc
@@ -146,7 +146,7 @@ class EndToEndTest(unittest.TestCase):
             cert_controller = CertController()
             cert_controller.app = app
             for security_server in self.config["security_server"]:
-                configuration = cert_controller.initialize_basic_config_values(security_server, self.config)
+                configuration = cert_controller.create_api_config(security_server, self.config)
                 cert_controller.remote_import_certificates(configuration, security_server)
 
     def step_cert_register(self):
@@ -154,7 +154,7 @@ class EndToEndTest(unittest.TestCase):
             cert_controller = CertController()
             cert_controller.app = app
             for security_server in self.config["security_server"]:
-                configuration = cert_controller.initialize_basic_config_values(security_server, self.config)
+                configuration = cert_controller.create_api_config(security_server, self.config)
                 cert_controller.remote_register_certificate(configuration, security_server)
 
     def step_cert_activate(self):
@@ -162,7 +162,7 @@ class EndToEndTest(unittest.TestCase):
             cert_controller = CertController()
             cert_controller.app = app
             for security_server in self.config["security_server"]:
-                configuration = cert_controller.initialize_basic_config_values(security_server, self.config)
+                configuration = cert_controller.create_api_config(security_server, self.config)
                 cert_controller.remote_activate_certificate(configuration, security_server)
 
     def step_subsystem_add_client(self):
@@ -170,7 +170,7 @@ class EndToEndTest(unittest.TestCase):
             client_controller = ClientController()
             client_controller.app = app
             for security_server in self.config["security_server"]:
-                configuration = client_controller.initialize_basic_config_values(security_server, self.config)
+                configuration = client_controller.create_api_config(security_server, self.config)
                 for client in security_server["clients"]:
                     client_controller.remote_add_client(configuration, client)
 
@@ -179,14 +179,14 @@ class EndToEndTest(unittest.TestCase):
             client_controller = ClientController()
             client_controller.app = app
             for security_server in self.config["security_server"]:
-                configuration = client_controller.initialize_basic_config_values(security_server, self.config)
+                configuration = client_controller.create_api_config(security_server, self.config)
                 for client in security_server["clients"]:
                     client_controller.remote_register_client(configuration, security_server, client)
 
     def step_add_service_description(self, client_id):
         service_controller = ServiceController()
         for security_server in self.config["security_server"]:
-            configuration = service_controller.initialize_basic_config_values(security_server, self.config)
+            configuration = service_controller.create_api_config(security_server, self.config)
             for client in security_server["clients"]:
                 for service_description in client["service_descriptions"]:
                     service_controller.remote_add_service_description(configuration, security_server, client, service_description)
@@ -196,7 +196,7 @@ class EndToEndTest(unittest.TestCase):
     def step_enable_service_description(self, client_id):
         service_controller = ServiceController()
         for security_server in self.config["security_server"]:
-            configuration = service_controller.initialize_basic_config_values(security_server, self.config)
+            configuration = service_controller.create_api_config(security_server, self.config)
             for client in security_server["clients"]:
                 for service_description in client["service_descriptions"]:
                     service_controller.remote_enable_service_description(configuration, security_server, client, service_description)
@@ -206,7 +206,7 @@ class EndToEndTest(unittest.TestCase):
     def step_add_service_access(self, client_id):
         service_controller = ServiceController()
         for security_server in self.config["security_server"]:
-            configuration = service_controller.initialize_basic_config_values(security_server, self.config)
+            configuration = service_controller.create_api_config(security_server, self.config)
             for client in security_server["clients"]:
                 for service_description in client["service_descriptions"]:
                     service_controller.remote_add_access_rights(configuration, security_server, client, service_description)
@@ -220,7 +220,7 @@ class EndToEndTest(unittest.TestCase):
         assert description["services"][0]["timeout"] == 60
         assert description["services"][0]["url"] == 'http://petstore.swagger.io/v1'
         for security_server in self.config["security_server"]:
-            configuration = service_controller.initialize_basic_config_values(security_server, self.config)
+            configuration = service_controller.create_api_config(security_server, self.config)
             for client in security_server["clients"]:
                 for service_description in client["service_descriptions"]:
                     service_controller.remote_update_service_parameters(configuration, security_server, client, service_description)

--- a/tests/integration/integration_base.py
+++ b/tests/integration/integration_base.py
@@ -11,6 +11,9 @@ from definitions import ROOT_DIR
 
 
 # Make less of many evils and use one abstract test class base for encapsulating rather involved Docker setup.
+from xrdsst.controllers.base import BaseController
+
+
 class IntegrationTestBase(unittest.TestCase):
     __test__ = False
     configuration_anchor = "tests/resources/configuration-anchor.xml"
@@ -21,7 +24,6 @@ class IntegrationTestBase(unittest.TestCase):
     docker_folder = local_folder + '/Docker/securityserver'
     image = 'xroad-security-server:latest'
     url = 'https://localhost:4000/api/v1/api-keys'
-    roles = '[\"XROAD_SYSTEM_ADMINISTRATOR\",\"XROAD_SERVICE_ADMINISTRATOR\", \"XROAD_SECURITY_OFFICER\", \"XROAD_REGISTRATION_OFFICER\"]'
     header = 'Content-Type: application/json'
     max_retries = 300
     retry_wait = 1  # in seconds
@@ -31,7 +33,6 @@ class IntegrationTestBase(unittest.TestCase):
     def init_config(self):
         self.config = {
             'admin_credentials': self.credentials,
-            'api_key_roles': json.loads(self.roles),
             'logging': {'file': '/var/log/xrdsst_test.log', 'level': 'INFO'},
             'ssh_access': {'user': 'user', 'private_key': 'key'},
             'security_server':
@@ -139,7 +140,7 @@ class IntegrationTestBase(unittest.TestCase):
             if container.name == self.name:
                 retries = 0
                 while retries <= self.max_retries:
-                    cmd = "curl -X POST -u " + self.credentials + " --silent " + self.url + " --data \'" + self.roles + \
+                    cmd = "curl -X POST -u " + self.credentials + " --silent " + self.url + " --data \'" + json.dumps(BaseController._TRANSIENT_API_KEY_ROLES) + \
                           "\'" + " --header \"" + self.header + "\" -k"
                     result = container.exec_run(cmd, stdout=True, stderr=True, demux=False)
                     if len(result.output) > 0:

--- a/tests/integration/test_xrdsst.py
+++ b/tests/integration/test_xrdsst.py
@@ -40,7 +40,7 @@ class TestXRDSST(IntegrationTestBase, IntegrationOpBase):
     def step_init(self):
         base = BaseController()
         init = InitServerController()
-        configuration = base.initialize_basic_config_values(self.config["security_server"][0], self.config)
+        configuration = base.create_api_config(self.config["security_server"][0], self.config)
         status = init.check_init_status(configuration)
         assert status.is_anchor_imported is False
         assert status.is_server_code_initialized is False

--- a/tests/resources/test-config-template.yaml
+++ b/tests/resources/test-config-template.yaml
@@ -1,9 +1,4 @@
 admin_credentials: <SECURITY_SERVER_CREDENTIALS>
-api_key_roles:
-- XROAD_SYSTEM_ADMINISTRATOR
-- XROAD_SERVICE_ADMINISTRATOR
-- XROAD_SECURITY_OFFICER
-- XROAD_REGISTRATION_OFFICER
 ssh_access:
   user: <SSH_USER>
   private_key: /path/to/ssh_private_key

--- a/tests/unit/test_auto.py
+++ b/tests/unit/test_auto.py
@@ -20,7 +20,6 @@ from xrdsst.main import XRDSSTTest
 class TestAuto(unittest.TestCase):
     ss_config = {
         'admin_credentials': 'user:pass',
-        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':
             [{'name': 'ssX',

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -22,7 +22,6 @@ class TestBaseController(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     _ss_config = {
         'admin_credentials': 'user:pass',
-        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -365,7 +365,7 @@ class TestBaseController(unittest.TestCase):
             os.remove("my_key")
             self.assertRaises(Exception)
 
-    def test_initialize_basic_conf_values(self):
+    def test_create_api_config(self):
         with XRDSSTTest() as app:
             base_controller = BaseController()
             base_controller.app = app
@@ -376,7 +376,7 @@ class TestBaseController(unittest.TestCase):
             configuration.api_key['Authorization'] = security_server["api_key"]
             configuration.host = security_server["url"]
             configuration.verify_ssl = False
-            response = base_controller.initialize_basic_config_values(security_server)
+            response = base_controller.create_api_config(security_server)
             os.remove(temp_file_name)
             assert response.api_key == configuration.api_key
             assert response.host == configuration.host

--- a/tests/unit/test_base_controller.py
+++ b/tests/unit/test_base_controller.py
@@ -27,7 +27,7 @@ class TestBaseController(unittest.TestCase):
         'security_server':
             [{'name': 'ss',
               'url': 'https://ss:4000/api/v1',
-              'api_key': 'X-Road-apikey token=<API_KEY>',
+              'api_key': 'X-Road-apikey token=f160830d-d75a-476e-a9ad-9c12abff00d3',
               'api_key_url': 'https://localhost:4000/api/v1/api-keys',
               'configuration_anchor': configuration_anchor,
               'owner_member_class': 'GOV',

--- a/tests/unit/test_cert.py
+++ b/tests/unit/test_cert.py
@@ -244,7 +244,6 @@ class TestCert(unittest.TestCase):
     authcert_existing = os.path.join(ROOT_DIR, "tests/resources/authcert.pem")
     ss_config = {
         'admin_credentials': 'user:pass',
-        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -31,7 +31,6 @@ class ClientTestData:
 class TestClient(unittest.TestCase):
     ss_config = {
         'admin_credentials': 'user:pass',
-        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -33,7 +33,6 @@ class TestInit(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     _ss_config = {
         'admin_credentials': 'user:pass',
-        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -36,7 +36,6 @@ class ServiceTestData:
 class TestService(unittest.TestCase):
     ss_config = {
         'admin_credentials': 'user:pass',
-        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -25,7 +25,6 @@ class TestStatus(unittest.TestCase):
     authcert_existing = os.path.join(ROOT_DIR, "tests/resources/authcert.pem")
     ss_config = {
         'admin_credentials': 'user:pass',
-        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':

--- a/tests/unit/test_timestamp.py
+++ b/tests/unit/test_timestamp.py
@@ -29,7 +29,6 @@ class TestTimestamp(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     ss_config = {
         'admin_credentials': 'user:pass',
-        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': str(Path.home()) + '/xrdsst_tests.log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':

--- a/tests/unit/test_timestamp.py
+++ b/tests/unit/test_timestamp.py
@@ -74,7 +74,7 @@ class TestTimestamp(unittest.TestCase):
                 timestamp_controller.app = app
                 timestamp_controller.load_config = (lambda: self.ss_config)
                 for security_server in self.ss_config["security_server"]:
-                    configuration = timestamp_controller.initialize_basic_config_values(security_server, self.ss_config)
+                    configuration = timestamp_controller.create_api_config(security_server, self.ss_config)
                     response = timestamp_controller.remote_get_configured(configuration)
                     assert response == TimestampTestData.timestamp_service_list_response
 
@@ -86,7 +86,7 @@ class TestTimestamp(unittest.TestCase):
                 timestamp_controller.app = app
                 timestamp_controller.load_config = (lambda: self.ss_config)
                 for security_server in self.ss_config["security_server"]:
-                    configuration = timestamp_controller.initialize_basic_config_values(security_server, self.ss_config)
+                    configuration = timestamp_controller.create_api_config(security_server, self.ss_config)
                     timestamp_controller.remote_get_configured(configuration)
                     self.assertRaises(ApiException)
 

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -189,7 +189,7 @@ class TestToken(unittest.TestCase):
                 token_controller.app = app
                 token_controller.load_config = (lambda: self.ss_config)
                 for security_server in self.ss_config["security_server"]:
-                    configuration = token_controller.initialize_basic_config_values(security_server, self.ss_config)
+                    configuration = token_controller.create_api_config(security_server, self.ss_config)
                     response = token_controller.remote_get_tokens(configuration)
                     assert response == TokenTestData.token_list_response
 
@@ -201,7 +201,7 @@ class TestToken(unittest.TestCase):
                 token_controller.app = app
                 token_controller.load_config = (lambda: self.ss_config)
                 for security_server in self.ss_config["security_server"]:
-                    configuration = token_controller.initialize_basic_config_values(security_server, self.ss_config)
+                    configuration = token_controller.create_api_config(security_server, self.ss_config)
                     token_controller.remote_get_tokens(configuration)
                     self.assertRaises(ApiException)
 

--- a/tests/unit/test_token.py
+++ b/tests/unit/test_token.py
@@ -151,7 +151,6 @@ class TestToken(unittest.TestCase):
     configuration_anchor = os.path.join(ROOT_DIR, "tests/resources/configuration-anchor.xml")
     ss_config = {
         'admin_credentials': 'user:pass',
-        'api_key_roles': ['XROAD_SYSTEM_ADMINISTRATOR'],
         'logging': {'file': '/tmp/xrdsst_test_token_log', 'level': 'INFO'},
         'ssh_access': {'user': 'user', 'private_key': 'key'},
         'security_server':

--- a/xrdsst/controllers/auto.py
+++ b/xrdsst/controllers/auto.py
@@ -34,6 +34,11 @@ class AutoController(BaseController):
 
         self.update_op_statuses(active_config)
 
+        ss_api_config = self.app.OP_GRAPH.nodes[self.app.OP_DEPENDENCY_LIST[0]]['servers'][ssn]['api_config']
+        if not ss_api_config:
+            self.log_info("SKIPPED AUTO ->'" + ssn + "'. " + texts['message.server.keyless'].format(ssn))
+            return
+
         first_status = self.app.OP_GRAPH.nodes[self.app.OP_DEPENDENCY_LIST[0]]['servers'][ssn]['status']
         if not first_status.connectivity_status[0]:
             self.log_info("SKIPPED AUTO ->'" + ssn + "' no connectivity, (" + first_status.connectivity_status[1] + ").")

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -130,7 +130,7 @@ class BaseController(Controller):
 
         for security_server in active_config["security_server"]:
             ssn = security_server['name']
-            api_config = self.initialize_basic_config_values(security_server, active_config)
+            api_config = self.create_api_config(security_server, active_config)
             status = self.get_server_status(api_config, security_server)
 
             for g_node in g:
@@ -379,12 +379,12 @@ class BaseController(Controller):
 
         return self.config
 
-    def initialize_basic_config_values(self, security_server, config=None):
-        configuration = Configuration()
-        configuration.api_key['Authorization'] = self.get_api_key(config, security_server)
-        configuration.host = security_server["url"]
-        configuration.verify_ssl = False
-        return configuration
+    def create_api_config(self, security_server, config=None):
+        api_config = Configuration()
+        api_config.api_key['Authorization'] = self.get_api_key(config, security_server)
+        api_config.host = security_server["url"]
+        api_config.verify_ssl = False
+        return api_config
 
     # Produces INFO level log and console printout about unconfigured servers details when executing single operation
     # (last operation in given /full_op_path/).

--- a/xrdsst/controllers/base.py
+++ b/xrdsst/controllers/base.py
@@ -33,6 +33,7 @@ BANNER = texts['app.description'] + ' ' + get_version() + '\n' + get_version_ban
 
 
 class BaseController(Controller):
+    _TRANSIENT_API_KEY_ROLES = ['XROAD_SYSTEM_ADMINISTRATOR', 'XROAD_SERVICE_ADMINISTRATOR', 'XROAD_SECURITY_OFFICER', 'XROAD_REGISTRATION_OFFICER']
     _DEFAULT_CONFIG_FILE = "config/xrdsst.yml"
     class Meta:
         label = 'base'
@@ -227,9 +228,8 @@ class BaseController(Controller):
         config = conf if conf else self.config
 
         if security_server.get(ConfKeysSecurityServer.CONF_KEY_API_KEY):
-            roles_list = config.get(ConfKeysRoot.CONF_KEY_ROOT_API_KEY_ROLES)
             try:
-                api_key = 'X-Road-apikey token=' + self.create_api_key(config, roles_list, security_server)
+                api_key = 'X-Road-apikey token=' + self.create_api_key(config, BaseController._TRANSIENT_API_KEY_ROLES, security_server)
                 self.app.api_keys[security_server[ConfKeysSecurityServer.CONF_KEY_NAME]] = api_key
             except Exception as err:
                 self.log_api_error('BaseController->get_api_key:', err)

--- a/xrdsst/controllers/cert.py
+++ b/xrdsst/controllers/cert.py
@@ -102,36 +102,36 @@ class CertController(BaseController):
         self.init_logging(configuration)
         for security_server in configuration["security_server"]:
             BaseController.log_debug('Starting certificate import process for security server: ' + security_server['name'])
-            ss_configuration = self.initialize_basic_config_values(security_server, configuration)
-            self.remote_import_certificates(ss_configuration, security_server)
+            ss_api_config = self.create_api_config(security_server, configuration)
+            self.remote_import_certificates(ss_api_config, security_server)
 
     def register_certificate(self, configuration):
         self.init_logging(configuration)
         for security_server in configuration["security_server"]:
             BaseController.log_debug('Starting certificate registration process for security server: ' + security_server['name'])
-            ss_configuration = self.initialize_basic_config_values(security_server, configuration)
-            self.remote_register_certificate(ss_configuration, security_server)
+            ss_api_config = self.create_api_config(security_server, configuration)
+            self.remote_register_certificate(ss_api_config, security_server)
 
     def activate_certificate(self, configuration):
         self.init_logging(configuration)
         for security_server in configuration["security_server"]:
             BaseController.log_debug('Starting certificate activation for security server: ' + security_server['name'])
-            ss_configuration = self.initialize_basic_config_values(security_server, configuration)
-            self.remote_activate_certificate(ss_configuration, security_server)
+            ss_api_config = self.create_api_config(security_server, configuration)
+            self.remote_activate_certificate(ss_api_config, security_server)
 
     def _download_csrs(self, configuration):
         self.init_logging(configuration)
         downloaded_csrs = []
         for security_server in configuration["security_server"]:
             BaseController.log_info('Starting CSR download from security server: ' + security_server['name'])
-            ss_configuration = self.initialize_basic_config_values(security_server, configuration)
-            downloaded_csrs.extend(self.remote_download_csrs(ss_configuration, security_server))
+            ss_api_config = self.create_api_config(security_server, configuration)
+            downloaded_csrs.extend(self.remote_download_csrs(ss_api_config, security_server))
         return downloaded_csrs
 
     # requires token to be logged in
     @staticmethod
-    def remote_import_certificates(ss_configuration, security_server):
-        token_cert_api = TokenCertificatesApi(ApiClient(ss_configuration))
+    def remote_import_certificates(ss_api_config, security_server):
+        token_cert_api = TokenCertificatesApi(ApiClient(ss_api_config))
         for cert in security_server["certificates"]:
             location = cement.utils.fs.join_exists(cert)
             if not location[1]:
@@ -151,12 +151,12 @@ class CertController(BaseController):
                         BaseController.log_api_error('TokenCertificatesApi->import_certificate', err)
 
     @staticmethod
-    def remote_register_certificate(ss_configuration, security_server):
-        registrable_cert = CertController.find_actionable_auth_certificate(ss_configuration, security_server, 'REGISTER')
+    def remote_register_certificate(ss_api_config, security_server):
+        registrable_cert = CertController.find_actionable_auth_certificate(ss_api_config, security_server, 'REGISTER')
         if not registrable_cert:
             return None
 
-        token_cert_api = TokenCertificatesApi(ApiClient(ss_configuration))
+        token_cert_api = TokenCertificatesApi(ApiClient(ss_api_config))
         ss_address = SecurityServerAddress(BaseController.security_server_address(security_server))
         try:
             response = token_cert_api.register_certificate(registrable_cert.certificate_details.hash, body=ss_address)
@@ -166,12 +166,12 @@ class CertController(BaseController):
             BaseController.log_api_error('TokenCertificatesApi->import_certificate', err)
 
     @staticmethod
-    def remote_activate_certificate(ss_configuration, security_server):
-        activatable_cert = CertController.find_actionable_auth_certificate(ss_configuration, security_server, 'ACTIVATE')
+    def remote_activate_certificate(ss_api_config, security_server):
+        activatable_cert = CertController.find_actionable_auth_certificate(ss_api_config, security_server, 'ACTIVATE')
         if not activatable_cert:
             return None
 
-        token_cert_api = TokenCertificatesApi(ApiClient(ss_configuration))
+        token_cert_api = TokenCertificatesApi(ApiClient(ss_api_config))
         token_cert_api.activate_certificate(activatable_cert.certificate_details.hash)  # responseless PUT
         cert_actions = token_cert_api.get_possible_actions_for_certificate(activatable_cert.certificate_details.hash)
         if 'ACTIVATE' not in cert_actions:
@@ -180,20 +180,20 @@ class CertController(BaseController):
             BaseController.log_info("Could not activate certificate " + activatable_cert.certificate_details.hash)
         return cert_actions
 
-    def remote_download_csrs(self, ss_configuration, security_server):
+    def remote_download_csrs(self, ss_api_config, security_server):
         key_labels = {
             'auth': default_auth_key_label(security_server),
             'sign': default_sign_key_label(security_server)
         }
 
-        token = remote_get_token(ss_configuration, security_server)
+        token = remote_get_token(ss_api_config, security_server)
         auth_keys = list(filter(lambda key: key.label == key_labels['auth'], token.keys))
         sign_keys = list(filter(lambda key: key.label == key_labels['sign'], token.keys))
 
         if not (auth_keys or sign_keys):
             return []
 
-        keys_api = KeysApi(ApiClient(ss_configuration))
+        keys_api = KeysApi(ApiClient(ss_api_config))
         downloaded_csrs = []
 
         for keytype in [(sign_keys, 'sign'), (auth_keys, 'auth')]:
@@ -228,8 +228,8 @@ class CertController(BaseController):
         return downloaded_csrs
 
     @staticmethod
-    def find_actionable_auth_certificate(ss_configuration, security_server, cert_action):
-        token = remote_get_token(ss_configuration, security_server)
+    def find_actionable_auth_certificate(ss_api_config, security_server, cert_action):
+        token = remote_get_token(ss_api_config, security_server)
         # Find the authentication certificate by conventional name
         auth_key_label = default_auth_key_label(security_server)
         auth_keys = list(filter(lambda key: key.label == auth_key_label, token.keys))

--- a/xrdsst/controllers/cert.py
+++ b/xrdsst/controllers/cert.py
@@ -98,34 +98,47 @@ class CertController(BaseController):
 
         return self._download_csrs(active_config)
 
-    def import_certificates(self, configuration):
-        self.init_logging(configuration)
-        for security_server in configuration["security_server"]:
+    def import_certificates(self, config):
+        self.init_logging(config)
+        ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
+
+        for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             BaseController.log_debug('Starting certificate import process for security server: ' + security_server['name'])
-            ss_api_config = self.create_api_config(security_server, configuration)
             self.remote_import_certificates(ss_api_config, security_server)
 
-    def register_certificate(self, configuration):
-        self.init_logging(configuration)
-        for security_server in configuration["security_server"]:
+        BaseController.log_keyless_servers(ss_api_conf_tuple)
+
+    def register_certificate(self, config):
+        self.init_logging(config)
+        ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
+
+        for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             BaseController.log_debug('Starting certificate registration process for security server: ' + security_server['name'])
-            ss_api_config = self.create_api_config(security_server, configuration)
             self.remote_register_certificate(ss_api_config, security_server)
 
-    def activate_certificate(self, configuration):
-        self.init_logging(configuration)
-        for security_server in configuration["security_server"]:
+        BaseController.log_keyless_servers(ss_api_conf_tuple)
+
+    def activate_certificate(self, config):
+        self.init_logging(config)
+        ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
+
+        for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             BaseController.log_debug('Starting certificate activation for security server: ' + security_server['name'])
-            ss_api_config = self.create_api_config(security_server, configuration)
             self.remote_activate_certificate(ss_api_config, security_server)
 
-    def _download_csrs(self, configuration):
-        self.init_logging(configuration)
+        BaseController.log_keyless_servers(ss_api_conf_tuple)
+
+    def _download_csrs(self, config):
+        self.init_logging(config)
         downloaded_csrs = []
-        for security_server in configuration["security_server"]:
+        ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
+
+        for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             BaseController.log_info('Starting CSR download from security server: ' + security_server['name'])
-            ss_api_config = self.create_api_config(security_server, configuration)
             downloaded_csrs.extend(self.remote_download_csrs(ss_api_config, security_server))
+
+        BaseController.log_keyless_servers(ss_api_conf_tuple)
+
         return downloaded_csrs
 
     # requires token to be logged in

--- a/xrdsst/controllers/client.py
+++ b/xrdsst/controllers/client.py
@@ -49,22 +49,22 @@ class ClientController(BaseController):
         self.init_logging(configuration)
         for security_server in configuration["security_server"]:
             BaseController.log_debug('Starting client add process for security server: ' + security_server['name'])
-            ss_configuration = self.initialize_basic_config_values(security_server, configuration)
+            ss_api_config = self.create_api_config(security_server, configuration)
             if "clients" in security_server:  # Guards both against empty section (->None) & complete lack of section
                 for client in security_server["clients"]:
-                    self.remote_add_client(ss_configuration, client)
+                    self.remote_add_client(ss_api_config, client)
 
     # This operation fails when global status is not up to date.
     def register_client(self, configuration):
         self.init_logging(configuration)
         for security_server in configuration["security_server"]:
             BaseController.log_debug('Starting client registrations for security server: ' + security_server['name'])
-            ss_configuration = self.initialize_basic_config_values(security_server, configuration)
+            ss_api_config = self.create_api_config(security_server, configuration)
             if "clients" in security_server:
                 for client in security_server["clients"]:
-                    self.remote_register_client(ss_configuration, security_server, client)
+                    self.remote_register_client(ss_api_config, security_server, client)
 
-    def remote_add_client(self, ss_configuration, client_conf):
+    def remote_add_client(self, ss_api_config, client_conf):
         conn_type = convert_swagger_enum(ConnectionType, client_conf['connection_type'])
         client = Client(member_class=client_conf['member_class'],
                         member_code=client_conf['member_code'],
@@ -72,7 +72,7 @@ class ClientController(BaseController):
                         connection_type=conn_type)
 
         client_add = ClientAdd(client=client, ignore_warnings=True)
-        clients_api = ClientsApi(ApiClient(ss_configuration))
+        clients_api = ClientsApi(ApiClient(ss_api_config))
         try:
             response = clients_api.add_client(body=client_add)
             BaseController.log_info("Added client subsystem " + self.partial_client_id(client_conf) + " (got full id " + response.id + ")")
@@ -83,8 +83,8 @@ class ClientController(BaseController):
             else:
                 BaseController.log_api_error('ClientsApi->add_client', err)
 
-    def remote_register_client(self, ss_configuration, security_server_conf, client_conf):
-        clients_api = ClientsApi(ApiClient(ss_configuration))
+    def remote_register_client(self, ss_api_config, security_server_conf, client_conf):
+        clients_api = ClientsApi(ApiClient(ss_api_config))
         try:
             client = self.find_client(clients_api, security_server_conf, client_conf)
             if client:

--- a/xrdsst/controllers/service.py
+++ b/xrdsst/controllers/service.py
@@ -71,49 +71,61 @@ class ServiceController(BaseController):
 
         self.update_service_parameters(active_config)
 
-    def add_service_description(self, configuration):
-        self.init_logging(configuration)
-        for security_server in configuration["security_server"]:
+    def add_service_description(self, config):
+        self.init_logging(config)
+        ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
+
+        for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             BaseController.log_debug('Starting service description add process for security server: ' + security_server['name'])
-            ss_api_config = self.create_api_config(security_server, configuration)
             if "clients" in security_server:
                 for client in security_server["clients"]:
                     if client.get("service_descriptions"):
                         for service_description in client["service_descriptions"]:
                             self.remote_add_service_description(ss_api_config, security_server, client, service_description)
 
-    def enable_service_description(self, configuration):
-        self.init_logging(configuration)
-        for security_server in configuration["security_server"]:
+        BaseController.log_keyless_servers(ss_api_conf_tuple)
+
+    def enable_service_description(self, config):
+        self.init_logging(config)
+        ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
+
+        for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             BaseController.log_debug('Starting service description enabling process for security server: ' + security_server['name'])
-            ss_api_config = self.create_api_config(security_server, configuration)
             if "clients" in security_server:
                 for client in security_server["clients"]:
                     if client.get("service_descriptions"):
                         for service_description in client["service_descriptions"]:
                             self.remote_enable_service_description(ss_api_config, security_server, client, service_description)
 
-    def add_access_rights(self, configuration):
-        self.init_logging(configuration)
-        for security_server in configuration["security_server"]:
+        BaseController.log_keyless_servers(ss_api_conf_tuple)
+
+    def add_access_rights(self, config):
+        self.init_logging(config)
+        ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
+
+        for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             BaseController.log_debug('Starting service description access adding process for security server: ' + security_server['name'])
-            ss_api_config = self.create_api_config(security_server, configuration)
             if "clients" in security_server:
                 for client in security_server["clients"]:
                     if "service_descriptions" in client:
                         for service_description in client["service_descriptions"]:
                             self.remote_add_access_rights(ss_api_config, security_server, client, service_description)
 
-    def update_service_parameters(self, configuration):
-        self.init_logging(configuration)
-        for security_server in configuration["security_server"]:
+        BaseController.log_keyless_servers(ss_api_conf_tuple)
+
+    def update_service_parameters(self, config):
+        self.init_logging(config)
+        ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
+
+        for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             BaseController.log_debug('Starting service description updating parameters process for security server: ' + security_server['name'])
-            ss_api_config = self.create_api_config(security_server, configuration)
             if "clients" in security_server:
                 for client in security_server["clients"]:
                     if "service_descriptions" in client:
                         for service_description in client["service_descriptions"]:
                             self.remote_update_service_parameters(ss_api_config, security_server, client, service_description)
+
+        BaseController.log_keyless_servers(ss_api_conf_tuple)
 
     @staticmethod
     def remote_add_service_description(ss_api_config, security_server_conf, client_conf, service_description_conf):

--- a/xrdsst/controllers/service.py
+++ b/xrdsst/controllers/service.py
@@ -75,54 +75,54 @@ class ServiceController(BaseController):
         self.init_logging(configuration)
         for security_server in configuration["security_server"]:
             BaseController.log_debug('Starting service description add process for security server: ' + security_server['name'])
-            ss_configuration = self.initialize_basic_config_values(security_server, configuration)
+            ss_api_config = self.create_api_config(security_server, configuration)
             if "clients" in security_server:
                 for client in security_server["clients"]:
                     if client.get("service_descriptions"):
                         for service_description in client["service_descriptions"]:
-                            self.remote_add_service_description(ss_configuration, security_server, client, service_description)
+                            self.remote_add_service_description(ss_api_config, security_server, client, service_description)
 
     def enable_service_description(self, configuration):
         self.init_logging(configuration)
         for security_server in configuration["security_server"]:
             BaseController.log_debug('Starting service description enabling process for security server: ' + security_server['name'])
-            ss_configuration = self.initialize_basic_config_values(security_server, configuration)
+            ss_api_config = self.create_api_config(security_server, configuration)
             if "clients" in security_server:
                 for client in security_server["clients"]:
                     if client.get("service_descriptions"):
                         for service_description in client["service_descriptions"]:
-                            self.remote_enable_service_description(ss_configuration, security_server, client, service_description)
+                            self.remote_enable_service_description(ss_api_config, security_server, client, service_description)
 
     def add_access_rights(self, configuration):
         self.init_logging(configuration)
         for security_server in configuration["security_server"]:
             BaseController.log_debug('Starting service description access adding process for security server: ' + security_server['name'])
-            ss_configuration = self.initialize_basic_config_values(security_server, configuration)
+            ss_api_config = self.create_api_config(security_server, configuration)
             if "clients" in security_server:
                 for client in security_server["clients"]:
                     if "service_descriptions" in client:
                         for service_description in client["service_descriptions"]:
-                            self.remote_add_access_rights(ss_configuration, security_server, client, service_description)
+                            self.remote_add_access_rights(ss_api_config, security_server, client, service_description)
 
     def update_service_parameters(self, configuration):
         self.init_logging(configuration)
         for security_server in configuration["security_server"]:
             BaseController.log_debug('Starting service description updating parameters process for security server: ' + security_server['name'])
-            ss_configuration = self.initialize_basic_config_values(security_server, configuration)
+            ss_api_config = self.create_api_config(security_server, configuration)
             if "clients" in security_server:
                 for client in security_server["clients"]:
                     if "service_descriptions" in client:
                         for service_description in client["service_descriptions"]:
-                            self.remote_update_service_parameters(ss_configuration, security_server, client, service_description)
+                            self.remote_update_service_parameters(ss_api_config, security_server, client, service_description)
 
     @staticmethod
-    def remote_add_service_description(ss_configuration, security_server_conf, client_conf, service_description_conf):
+    def remote_add_service_description(ss_api_config, security_server_conf, client_conf, service_description_conf):
         code = service_description_conf['rest_service_code'] if service_description_conf['rest_service_code'] else None
         description_add = ServiceDescriptionAdd(url=service_description_conf['url'],
                                                 rest_service_code=code,
                                                 ignore_warnings=True,
                                                 type=service_description_conf['type'])
-        clients_api = ClientsApi(ApiClient(ss_configuration))
+        clients_api = ClientsApi(ApiClient(ss_api_config))
         try:
             client_controller = ClientController()
             client = client_controller.find_client(clients_api, security_server_conf, client_conf)
@@ -142,9 +142,9 @@ class ServiceController(BaseController):
         except ApiException as find_err:
             BaseController.log_api_error('ClientsApi->find_clients', find_err)
 
-    def remote_enable_service_description(self, ss_configuration, security_server_conf, client_conf, service_description_conf):
-        clients_api = ClientsApi(ApiClient(ss_configuration))
-        service_descriptions_api = ServiceDescriptionsApi(ApiClient(ss_configuration))
+    def remote_enable_service_description(self, ss_api_config, security_server_conf, client_conf, service_description_conf):
+        clients_api = ClientsApi(ApiClient(ss_api_config))
+        service_descriptions_api = ServiceDescriptionsApi(ApiClient(ss_api_config))
         try:
             client_controller = ClientController()
             client = client_controller.find_client(clients_api, security_server_conf, client_conf)
@@ -167,8 +167,8 @@ class ServiceController(BaseController):
         except ApiException as find_err:
             BaseController.log_api_error('ClientsApi->find_clients', find_err)
 
-    def remote_add_access_rights(self, ss_configuration, security_server_conf, client_conf, service_description_conf):
-        clients_api = ClientsApi(ApiClient(ss_configuration))
+    def remote_add_access_rights(self, ss_api_config, security_server_conf, client_conf, service_description_conf):
+        clients_api = ClientsApi(ApiClient(ss_api_config))
         try:
             client_controller = ClientController()
             client = client_controller.find_client(clients_api, security_server_conf, client_conf)
@@ -179,7 +179,7 @@ class ServiceController(BaseController):
                         for service in service_description.services:
                             try:
                                 client_id = None
-                                services_api = ServicesApi(ApiClient(ss_configuration))
+                                services_api = ServicesApi(ApiClient(ss_api_config))
                                 access_list = service_description_conf["access"] if service_description_conf["access"] else []
                                 configurable_services = service_description_conf["services"] if service_description_conf["services"] else []
                                 for configurable_service in configurable_services:
@@ -208,8 +208,8 @@ class ServiceController(BaseController):
         except ApiException as find_err:
             BaseController.log_api_error('ClientsApi->find_clients', find_err)
 
-    def remote_update_service_parameters(self, ss_configuration, security_server_conf, client_conf, service_description_conf):
-        clients_api = ClientsApi(ApiClient(ss_configuration))
+    def remote_update_service_parameters(self, ss_api_config, security_server_conf, client_conf, service_description_conf):
+        clients_api = ClientsApi(ApiClient(ss_api_config))
         try:
             client_controller = ClientController()
             client = client_controller.find_client(clients_api, security_server_conf, client_conf)
@@ -219,7 +219,7 @@ class ServiceController(BaseController):
                     if service_description:
                         for service in service_description.services:
                             try:
-                                services_api = ServicesApi(ApiClient(ss_configuration))
+                                services_api = ServicesApi(ApiClient(ss_api_config))
                                 timeout = None
                                 timeout_all = service_description_conf["timeout_all"]
                                 ssl_auth = None

--- a/xrdsst/controllers/status.py
+++ b/xrdsst/controllers/status.py
@@ -117,8 +117,8 @@ class StatusController(BaseController):
         servers = []
         if configuration.get("security_server"):
             for security_server in configuration["security_server"]:
-                ss_configuration = self.initialize_basic_config_values(security_server, configuration)
-                servers.append(self.remote_status(ss_configuration, security_server))
+                ss_api_config = self.create_api_config(security_server, configuration)
+                servers.append(self.remote_status(ss_api_config, security_server))
 
         if self.is_output_tabulated():
             render_data = [StatusListMapper.headers()]

--- a/xrdsst/controllers/timestamp.py
+++ b/xrdsst/controllers/timestamp.py
@@ -66,15 +66,21 @@ class TimestampController(BaseController):
         self.timestamp_service_init(active_config)
 
     # Since this is read-only operation, do not log anything, only console output
-    def timestamp_service_list(self, configuration):
-        for security_server in configuration["security_server"]:
-            ss_api_config = self.create_api_config(security_server, configuration)
+    def timestamp_service_list(self, config):
+        ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
+
+        for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             self.remote_timestamp_service_list(ss_api_config)
 
-    def timestamp_service_list_approved(self, configuration):
-        for security_server in configuration["security_server"]:
-            ss_api_config = self.create_api_config(security_server, configuration)
+        BaseController.log_keyless_servers(ss_api_conf_tuple)
+
+    def timestamp_service_list_approved(self, config):
+        ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
+
+        for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             self.remote_timestamp_service_list_approved(ss_api_config)
+
+        BaseController.log_keyless_servers(ss_api_conf_tuple)
 
     def render_timestamping_services(self, ts_list):
         render_data = []
@@ -114,11 +120,14 @@ class TimestampController(BaseController):
         except ApiException as e:
             print("Exception when listing timestamping services: %s\n", e)
 
-    def timestamp_service_init(self, configuration):  # logging required
-        self.init_logging(configuration)
-        for security_server in configuration["security_server"]:
-            ss_api_config = self.create_api_config(security_server, configuration)
+    def timestamp_service_init(self, config):  # logging required
+        self.init_logging(config)
+        ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
+
+        for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             self.remote_timestamp_service_init(ss_api_config, security_server)
+
+        BaseController.log_keyless_servers(ss_api_conf_tuple)
 
     def remote_timestamp_service_init(self, ss_api_config, security_server):
         try:

--- a/xrdsst/controllers/timestamp.py
+++ b/xrdsst/controllers/timestamp.py
@@ -68,13 +68,13 @@ class TimestampController(BaseController):
     # Since this is read-only operation, do not log anything, only console output
     def timestamp_service_list(self, configuration):
         for security_server in configuration["security_server"]:
-            ss_config = self.initialize_basic_config_values(security_server, configuration)
-            self.remote_timestamp_service_list(ss_config)
+            ss_api_config = self.create_api_config(security_server, configuration)
+            self.remote_timestamp_service_list(ss_api_config)
 
     def timestamp_service_list_approved(self, configuration):
         for security_server in configuration["security_server"]:
-            ss_config = self.initialize_basic_config_values(security_server, configuration)
-            self.remote_timestamp_service_list_approved(ss_config)
+            ss_api_config = self.create_api_config(security_server, configuration)
+            self.remote_timestamp_service_list_approved(ss_api_config)
 
     def render_timestamping_services(self, ts_list):
         render_data = []
@@ -94,21 +94,21 @@ class TimestampController(BaseController):
             print("Exception when listing timestamping services: %s\n", e)
 
     @staticmethod
-    def get_approved_timestamping_services(ss_configuration):
-        timestamping_api = TimestampingServicesApi(ApiClient(ss_configuration))
+    def get_approved_timestamping_services(ss_api_config):
+        timestamping_api = TimestampingServicesApi(ApiClient(ss_api_config))
         return timestamping_api.get_approved_timestamping_services()
 
-    def remote_timestamp_service_list_approved(self, ss_configuration):
-        self.remote_ts_list(lambda: self.get_approved_timestamping_services(ss_configuration))
+    def remote_timestamp_service_list_approved(self, ss_api_config):
+        self.remote_ts_list(lambda: self.get_approved_timestamping_services(ss_api_config))
 
-    def remote_timestamp_service_list(self, ss_configuration):
-        system_api = SystemApi(ApiClient(ss_configuration))
+    def remote_timestamp_service_list(self, ss_api_config):
+        system_api = SystemApi(ApiClient(ss_api_config))
         self.remote_ts_list(lambda: system_api.get_configured_timestamping_services())
 
     @staticmethod
-    def remote_get_configured(ss_configuration):
+    def remote_get_configured(ss_api_config):
         try:
-            system_api = SystemApi(ApiClient(ss_configuration))
+            system_api = SystemApi(ApiClient(ss_api_config))
             ts_list_response = system_api.get_configured_timestamping_services()
             return ts_list_response
         except ApiException as e:
@@ -117,14 +117,14 @@ class TimestampController(BaseController):
     def timestamp_service_init(self, configuration):  # logging required
         self.init_logging(configuration)
         for security_server in configuration["security_server"]:
-            ss_config = self.initialize_basic_config_values(security_server, configuration)
-            self.remote_timestamp_service_init(ss_config, security_server)
+            ss_api_config = self.create_api_config(security_server, configuration)
+            self.remote_timestamp_service_init(ss_api_config, security_server)
 
-    def remote_timestamp_service_init(self, ss_configuration, security_server):
+    def remote_timestamp_service_init(self, ss_api_config, security_server):
         try:
-            approved_ts = self.get_approved_timestamping_services(ss_configuration)
+            approved_ts = self.get_approved_timestamping_services(ss_api_config)
             if approved_ts:
-                system_api = SystemApi(ApiClient(ss_configuration))
+                system_api = SystemApi(ApiClient(ss_api_config))
                 ts_init_response = system_api.add_configured_timestamping_service(
                     body=TimestampingService(name=approved_ts[0].name, url=approved_ts[0].url)
                 )

--- a/xrdsst/controllers/token.py
+++ b/xrdsst/controllers/token.py
@@ -77,9 +77,10 @@ class TokenController(BaseController):
 
     def token_list(self, config):
         self.init_logging(config)
-        for security_server in config["security_server"]:
-            ss_api_config = self.create_api_config(security_server, config)
+        ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
+        for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             self.remote_token_list(ss_api_config)
+        BaseController.log_keyless_servers(ss_api_conf_tuple)
 
     # Since this is read-only operation, do not log anything, only console output
     def remote_token_list(self, ss_api_config):
@@ -106,12 +107,15 @@ class TokenController(BaseController):
         except ApiException as err:
             print("Exception when calling TokensApi->get_tokens: %s\n" % err)
 
-    def token_login(self, configuration):
-        self.init_logging(configuration)
-        for security_server in configuration["security_server"]:
+    def token_login(self, config):
+        self.init_logging(config)
+        ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
+
+        for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             BaseController.log_debug('Starting token login process for security server: ' + security_server['name'])
-            ss_api_config = self.create_api_config(security_server, configuration)
             self.remote_token_login(ss_api_config, security_server)
+
+        BaseController.log_keyless_servers(ss_api_conf_tuple)
 
     @staticmethod
     def remote_token_login(ss_api_config, security_server):
@@ -131,12 +135,15 @@ class TokenController(BaseController):
             else:
                 BaseController.log_api_error('TokensApi->login_token', err)
 
-    def token_add_keys_with_csrs(self, configuration):
-        self.init_logging(configuration)
-        for security_server in configuration["security_server"]:
+    def token_add_keys_with_csrs(self, config):
+        self.init_logging(config)
+        ss_api_conf_tuple = list(zip(config["security_server"], map(lambda ss: self.create_api_config(ss, config), config["security_server"])))
+
+        for security_server, ss_api_config in [t for t in ss_api_conf_tuple if t[1]]:
             BaseController.log_debug('Starting token key creation process for security server: ' + security_server['name'])
-            ss_api_config = self.create_api_config(security_server, configuration)
             self.remote_token_add_keys_with_csrs(ss_api_config, security_server)
+
+        BaseController.log_keyless_servers(ss_api_conf_tuple)
 
     # requires token to be logged in
     @staticmethod

--- a/xrdsst/core/api_util.py
+++ b/xrdsst/core/api_util.py
@@ -6,6 +6,7 @@ from xrdsst.api_client.api_client import ApiClient
 from xrdsst.core.conf_keys import ConfKeysSecurityServer
 from xrdsst.core.util import default_auth_key_label, default_sign_key_label, is_ss_connectable
 from xrdsst.models import KeyUsageType, CertificateStatus
+from xrdsst.resources.texts import texts
 from xrdsst.rest.rest import ApiException
 
 
@@ -534,10 +535,18 @@ def status_server(api_config, security_server):
             roles_status=StatusRoles(permitted=False, roles=None)
         )
 
+    # Only after 'physical' connectivity errors are reported, consider also API KEY availability.
+    if not api_config:
+        return ServerStatus(
+            connectivity_status=(False, texts['message.server.keyless'].format(security_server[ConfKeysSecurityServer.CONF_KEY_NAME])),
+            security_server_name=security_server["name"],
+            roles_status=StatusRoles(permitted=False, roles=None)
+        )
+
     roles_status = status_roles(api_config)
     if not roles_status.permitted:
         return ServerStatus(
-            connectivity_status=(is_connectable, conn_err_msg),
+            connectivity_status=(False, 'API KEY invalid or no access permitted'),
             security_server_name=security_server["name"],
             roles_status=roles_status
         )

--- a/xrdsst/core/conf_keys.py
+++ b/xrdsst/core/conf_keys.py
@@ -36,7 +36,6 @@ def validate_conf_keys(xrdsst_conf):
 class ConfKeysRoot:
     CONF_KEY_ROOT_SERVER = 'security_server'
     CONF_KEY_ROOT_ADMIN_CREDENTIALS = 'admin_credentials'
-    CONF_KEY_ROOT_API_KEY_ROLES = 'api_key_roles'
     CONF_KEY_ROOT_SSH_ACCESS = 'ssh_access'
     CONF_KEY_ROOT_LOGGING = 'logging'
 

--- a/xrdsst/core/version.py
+++ b/xrdsst/core/version.py
@@ -1,7 +1,7 @@
 """Module for getting project version"""
 from cement.utils.version import get_version as cement_get_version
 
-CURRENT_VERSION = "0.3.2-alpha.0"
+CURRENT_VERSION = "0.3.3-alpha.0"
 
 
 def convert_version(version_str):

--- a/xrdsst/resources/texts.py
+++ b/xrdsst/resources/texts.py
@@ -21,6 +21,7 @@ texts = {
     'message.file.unreadable': "Could not read file '{}'.",
     'message.config.unparsable': "Error parsing config: {}",
     'message.config.serverless': "No security servers defined in '{}'.",
+    'message.server.keyless': "No API key available/acquired for '{}'.",
     'message.skipped': "SKIPPED '{}'"
 }
 


### PR DESCRIPTION
Various release TODO, part 3:

* DOC: note that toolkit provides some extra information on distributed system failure source (Friday 19th session)
* DOC: document the restoration possibility from daily secserver backups (30 day retention), section 'Recovery from misconfiguration'. (From 22.03 threat-modeling session notes), 
* DOC, CODE: remove undocumented configuration element ``api_key_roles`` that is used to supply transient API key roles, roles for transient key added in the application (Slack 31.03, Teams 01.04)
* CODE: Stop toolkits' attempts to further communicate with security server when API key is not available (Slack 31.03)
   - rename ``initialize_basic_config_values``->``create_api_config``
   - ``create_api_config`` to return None if no API key available
   - operation attempts only on the servers with available ``api_config`` / accepted API key