### PR TITLE
Dockerized toolkit

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3
+
+WORKDIR /usr/src
+
+RUN apt-get -qq update \
+    && apt-get -qq upgrade \
+    && apt-get -qq install \
+    && apt-get -qq install git \
+    && apt-get -qq install jq \
+    && pip install virtualenv
+
+RUN git clone --branch v2.0 https://github.com/nordic-institute/X-Road-Security-Server-toolkit.git toolkit \
+    && cd toolkit \
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip install --extra-index-url http://niis-xrdsst-development.s3-website-eu-west-1.amazonaws.com/ xrdsst --trusted-host niis-xrdsst-development.s3-website-eu-west-1.amazonaws.com \
+    && make virtualenv
+
+RUN mkdir -p ssh_keys \
+    && ssh-keygen -f ./ssh_keys/id_rsa
+
+CMD bash -l

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,14 +7,13 @@ Note that:
 - this Dockerfile clones toolkit with tag v2.0 statically
 - ssh keys are generated in docker build phase to /usr/src/ssh -folder
 
-### Setup to configure a central server
+### Setup
 
-Normal requirements for a toolkit apply:
-- Central server and configured security server with management services are required
+[Normal requirements for a toolkit apply](https://github.com/nordic-institute/X-Road-Security-Server-toolkit/blob/master/docs/xroad_security_server_toolkit_user_guide.md#3-configuration-of-x-road-security-server)
 
 - docker-compose - configured docker network must provide access from toolkit container to ss1. This docker compose introduces xroad-network named bridge network.
-- configuration-anchor - introduce configuration anchor from your setups central server
-- configuration.yml - introduce your configuration file to this folder in order for it to mounted to the toolkit container
+- configuration-anchor - introduce configuration anchor from your central server to this folder in order for it to be mounted to the toolkit container
+- configuration.yml - introduce your configuration file to this folder in order for it to be mounted to the toolkit container
 
 ### Usage
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,27 @@
+
+# Dockerized X-Road-Security-Server-toolkit
+
+With these tools one doesn't have to install python to local machine in order to use toolkit. 
+
+Note that:
+- this Dockerfile clones toolkit with tag v2.0 statically
+- ssh keys are generated in docker build phase to /usr/src/ssh -folder
+
+### Setup to configure a central server
+
+Normal requirements for a toolkit apply:
+- Central server and configured security server with management services are required
+
+- docker-compose - configured docker network must provide access from toolkit container to ss1. This docker compose introduces xroad-network named bridge network.
+- configuration-anchor - introduce configuration anchor from your setups central server
+- configuration.yml - introduce your configuration file to this folder in order for it to mounted to the toolkit container
+
+### Usage
+
+```
+docker-compose build
+docker-compose run --rm toolkit
+source ./toolkit/env/bin/activate
+```
+
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.7'
+services:
+  toolkit:
+    image: toolkit-dev
+    container_name: toolkit
+    networks:
+      - xroad-network
+    build: .
+    volumes:
+      - .:/usr/src/configuration/:delegated
+
+networks:
+  xroad-network:
+    name: xroad-network
+    driver: bridge


### PR DESCRIPTION
This PR contains a basis for running toolkit inside a docker container so that toolkit users don't have to any other installations (like python) on their local machine. 



